### PR TITLE
feat: StaticMapLoader로 정적 장애물을 ObstacleStore에 적재 (#3)

### DIFF
--- a/src/turtle_agent/config/static_obstacles_turtlesim.yaml
+++ b/src/turtle_agent/config/static_obstacles_turtlesim.yaml
@@ -1,0 +1,27 @@
+# Turtlesim default window: x and y span [0, 11] (inclusive). Walls as four edges
+# for use with circle-vs-segment collision checks (collision_geometry.any_segment_intersects_disc).
+obstacles:
+  - id: wall-south
+    kind: static
+    geometry:
+      type: segments
+      segments:
+        - [ [ 0.0, 0.0 ], [ 11.0, 0.0 ] ]
+  - id: wall-east
+    kind: static
+    geometry:
+      type: segments
+      segments:
+        - [ [ 11.0, 0.0 ], [ 11.0, 11.0 ] ]
+  - id: wall-north
+    kind: static
+    geometry:
+      type: segments
+      segments:
+        - [ [ 11.0, 11.0 ], [ 0.0, 11.0 ] ]
+  - id: wall-west
+    kind: static
+    geometry:
+      type: segments
+      segments:
+        - [ [ 0.0, 11.0 ], [ 0.0, 0.0 ] ]

--- a/src/turtle_agent/scripts/static_map_loader.py
+++ b/src/turtle_agent/scripts/static_map_loader.py
@@ -1,0 +1,317 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Load static obstacles from YAML/JSON or ROS param into :class:`ObstacleStore`.
+
+YAML/JSON document shape::
+
+    obstacles:
+      - id: wall-south
+        kind: static   # optional; omitted defaults to static
+        geometry:
+          type: segments
+          segments:
+            - [[0.0, 0.0], [11.0, 0.0]]
+
+Field mapping (file keys → :mod:`obstacle_store` types):
+
+- ``id`` (str, required) → :attr:`Obstacle.id`
+- ``kind`` (str, optional) → :attr:`Obstacle.kind`; must be ``\"static\"`` if set.
+  Omitted defaults to ``\"static\"``.
+- ``geometry.type``:
+
+  - ``circle`` — keys ``cx``, ``cy``, ``r`` (numbers) → :class:`CircleGeometry`
+  - ``aabb`` — ``min_x``, ``min_y``, ``max_x``, ``max_y`` → :class:`AabbGeometry`
+  - ``segments`` — ``segments`` is a list of ``[[x1,y1],[x2,y2]]`` pairs →
+    :class:`SegmentsGeometry` (same tuple layout as :class:`collision_geometry.Segment`)
+
+- ``expires_at`` is not supported here; static obstacles use ``expires_at=None``.
+
+**Duplicate ids:** default ``on_duplicate_id=\"replace\"`` matches :meth:`ObstacleStore.upsert`
+(last write wins). With ``on_duplicate_id=\"error\"``, an id already present in the store
+(or duplicated earlier in the same document) raises :exc:`StaticMapLoadError`.
+
+**Files:** :func:`load_file` uses the path suffix (``.yaml``/``.yml`` → PyYAML,
+``.json`` → :mod:`json`). Other paths try JSON first, then YAML.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Tuple,
+    Union,
+)
+
+import yaml
+
+from obstacle_store import (
+    AabbGeometry,
+    CircleGeometry,
+    Obstacle,
+    ObstacleGeometry,
+    ObstacleStore,
+    SegmentsGeometry,
+)
+
+OnDuplicateId = Literal["replace", "error"]
+
+
+class StaticMapLoadError(ValueError):
+    """Invalid static map data or policy violation (duplicate id, wrong kind, etc.)."""
+
+
+def _err(
+    msg: str, *, source: Optional[str] = None, index: Optional[int] = None
+) -> StaticMapLoadError:
+    parts = [msg]
+    if source is not None:
+        parts.append(f"source={source!r}")
+    if index is not None:
+        parts.append(f"index={index}")
+    return StaticMapLoadError("; ".join(parts))
+
+
+def _coerce_float(
+    x: Any, *, key: str, source: Optional[str], index: Optional[int]
+) -> float:
+    if isinstance(x, bool) or not isinstance(x, (int, float)):
+        raise _err(
+            f"{key} must be a number, got {type(x).__name__}",
+            source=source,
+            index=index,
+        )
+    return float(x)
+
+
+def _parse_segment(
+    raw: Any, *, source: Optional[str], index: Optional[int], seg_index: int
+) -> Tuple[Tuple[float, float], Tuple[float, float]]:
+    if not isinstance(raw, (list, tuple)) or len(raw) != 2:
+        raise _err(
+            f"segments[{seg_index}] must be [p1, p2]",
+            source=source,
+            index=index,
+        )
+    p1, p2 = raw
+    if not isinstance(p1, (list, tuple)) or len(p1) != 2:
+        raise _err(
+            f"segments[{seg_index}][0] must be [x,y]", source=source, index=index
+        )
+    if not isinstance(p2, (list, tuple)) or len(p2) != 2:
+        raise _err(
+            f"segments[{seg_index}][1] must be [x,y]", source=source, index=index
+        )
+    x1 = _coerce_float(p1[0], key="x1", source=source, index=index)
+    y1 = _coerce_float(p1[1], key="y1", source=source, index=index)
+    x2 = _coerce_float(p2[0], key="x2", source=source, index=index)
+    y2 = _coerce_float(p2[1], key="y2", source=source, index=index)
+    return ((x1, y1), (x2, y2))
+
+
+def _parse_geometry(
+    geom: Any, *, source: Optional[str], index: Optional[int]
+) -> ObstacleGeometry:
+    if not isinstance(geom, MutableMapping):
+        raise _err("geometry must be a mapping", source=source, index=index)
+    gtype = geom.get("type")
+    if gtype is None:
+        raise _err("geometry.type is required", source=source, index=index)
+    if not isinstance(gtype, str):
+        raise _err("geometry.type must be a string", source=source, index=index)
+    gtype_l = gtype.strip().lower()
+    if gtype_l == "circle":
+        for k in ("cx", "cy", "r"):
+            if k not in geom:
+                raise _err(
+                    f"geometry.{k} is required for circle", source=source, index=index
+                )
+        return CircleGeometry(
+            _coerce_float(geom["cx"], key="cx", source=source, index=index),
+            _coerce_float(geom["cy"], key="cy", source=source, index=index),
+            _coerce_float(geom["r"], key="r", source=source, index=index),
+        )
+    if gtype_l == "aabb":
+        for k in ("min_x", "min_y", "max_x", "max_y"):
+            if k not in geom:
+                raise _err(
+                    f"geometry.{k} is required for aabb", source=source, index=index
+                )
+        return AabbGeometry(
+            _coerce_float(geom["min_x"], key="min_x", source=source, index=index),
+            _coerce_float(geom["min_y"], key="min_y", source=source, index=index),
+            _coerce_float(geom["max_x"], key="max_x", source=source, index=index),
+            _coerce_float(geom["max_y"], key="max_y", source=source, index=index),
+        )
+    if gtype_l == "segments":
+        if "segments" not in geom:
+            raise _err(
+                "geometry.segments is required for segments", source=source, index=index
+            )
+        segs_raw = geom["segments"]
+        if not isinstance(segs_raw, (list, tuple)):
+            raise _err("geometry.segments must be a list", source=source, index=index)
+        segs: List[Tuple[Tuple[float, float], Tuple[float, float]]] = [
+            _parse_segment(s, source=source, index=index, seg_index=i)
+            for i, s in enumerate(segs_raw)
+        ]
+        return SegmentsGeometry(tuple(segs))
+    raise _err(
+        f"unknown geometry.type {gtype!r} (expected circle, aabb, segments)",
+        source=source,
+        index=index,
+    )
+
+
+def _parse_obstacle_entry(raw: Any, *, source: Optional[str], index: int) -> Obstacle:
+    if not isinstance(raw, MutableMapping):
+        raise _err("obstacle entry must be a mapping", source=source, index=index)
+    oid = raw.get("id")
+    if oid is None or not isinstance(oid, str) or not oid.strip():
+        raise _err("id must be a non-empty string", source=source, index=index)
+    kind = raw.get("kind", "static")
+    if not isinstance(kind, str):
+        raise _err("kind must be a string", source=source, index=index)
+    kind_l = kind.strip().lower()
+    if kind_l != "static":
+        raise _err(
+            f"only static obstacles are supported, got kind={kind!r}",
+            source=source,
+            index=index,
+        )
+    if "geometry" not in raw:
+        raise _err("geometry is required", source=source, index=index)
+    geometry = _parse_geometry(raw["geometry"], source=source, index=index)
+    return Obstacle(id=oid.strip(), kind="static", geometry=geometry, expires_at=None)
+
+
+def load_into_store(
+    store: ObstacleStore,
+    data: Mapping[str, Any],
+    *,
+    on_duplicate_id: OnDuplicateId = "replace",
+    source: Optional[str] = None,
+) -> int:
+    """Parse ``data`` (must contain key ``obstacles``: list) and upsert into ``store``.
+
+    Returns the number of obstacles loaded.
+    """
+    if "obstacles" not in data:
+        raise _err("root key 'obstacles' is required", source=source, index=None)
+    items = data["obstacles"]
+    if not isinstance(items, list):
+        raise _err("'obstacles' must be a list", source=source, index=None)
+
+    seen_in_doc: set[str] = set()
+    count = 0
+    for i, raw in enumerate(items):
+        ob = _parse_obstacle_entry(raw, source=source, index=i)
+        if on_duplicate_id == "error":
+            if ob.id in seen_in_doc:
+                raise _err(
+                    f"duplicate id {ob.id!r} in same document",
+                    source=source,
+                    index=i,
+                )
+            if store.get(ob.id) is not None:
+                raise _err(
+                    f"id {ob.id!r} already exists in store",
+                    source=source,
+                    index=i,
+                )
+        seen_in_doc.add(ob.id)
+        store.upsert(ob)
+        count += 1
+    return count
+
+
+def _parse_file_bytes(raw: bytes, path: Path) -> Dict[str, Any]:
+    text = raw.decode("utf-8")
+    suf = path.suffix.lower()
+    if suf == ".json":
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as e:
+            raise StaticMapLoadError(f"invalid JSON in {path}: {e}") from e
+    elif suf in (".yaml", ".yml"):
+        try:
+            parsed = yaml.safe_load(text)
+        except yaml.YAMLError as e:
+            raise StaticMapLoadError(f"invalid YAML in {path}: {e}") from e
+    else:
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            try:
+                parsed = yaml.safe_load(text)
+            except yaml.YAMLError as e:
+                raise StaticMapLoadError(
+                    f"file {path} is not valid JSON or YAML: {e}"
+                ) from e
+    if not isinstance(parsed, dict):
+        raise StaticMapLoadError(
+            f"document root in {path} must be a mapping, got {type(parsed)}"
+        )
+    return parsed
+
+
+def load_file(
+    store: ObstacleStore,
+    path: Union[str, Path],
+    *,
+    on_duplicate_id: OnDuplicateId = "replace",
+) -> int:
+    """Load obstacles from a YAML or JSON file into ``store``."""
+    p = Path(path).expanduser()
+    if not p.is_file():
+        raise StaticMapLoadError(f"not a file: {p}")
+    data = _parse_file_bytes(p.read_bytes(), p)
+    return load_into_store(store, data, on_duplicate_id=on_duplicate_id, source=str(p))
+
+
+def load_from_rosparam(
+    store: ObstacleStore,
+    param_name: str = "~static_obstacles",
+    *,
+    on_duplicate_id: OnDuplicateId = "replace",
+) -> int:
+    """Load from ``rospy.get_param(param_name)`` (dict with ``obstacles`` or a list of entries)."""
+    import rospy
+
+    raw: Any = rospy.get_param(param_name, None)
+    if raw is None:
+        return 0
+    if isinstance(raw, list):
+        data: Dict[str, Any] = {"obstacles": raw}
+    elif isinstance(raw, dict):
+        data = raw
+    else:
+        raise StaticMapLoadError(
+            f"param {param_name!r} must be a dict or list, got {type(raw).__name__}"
+        )
+    return load_into_store(
+        store,
+        
+        data,
+        on_duplicate_id=on_duplicate_id,
+        source=f"rosparam:{param_name}",
+    )

--- a/src/turtle_agent/scripts/turtle_agent.py
+++ b/src/turtle_agent/scripts/turtle_agent.py
@@ -19,6 +19,7 @@ import signal
 import sys
 import threading
 from datetime import datetime
+from typing import Optional
 
 import dotenv
 import pyinputplus as pyip
@@ -36,9 +37,11 @@ from rosa import ROSA
 
 import tools.turtle as turtle_tools
 from help import get_help
+from obstacle_store import ObstacleStore
 from pose_logger import PoseLogger
 from llm import get_llm
 from prompts import get_prompts
+from static_map_loader import StaticMapLoadError, load_file
 
 
 def _maybe_attach_debugpy() -> None:
@@ -100,8 +103,14 @@ def cool_turtle_tool():
 
 class TurtleAgent(ROSA):
 
-    def __init__(self, streaming: bool = False, verbose: bool = True):
+    def __init__(
+        self,
+        streaming: bool = False,
+        verbose: bool = True,
+        obstacle_store: Optional[ObstacleStore] = None,
+    ):
         self.__blacklist = ["master", "docker"]
+        self._obstacle_store = obstacle_store
         self.__prompts = get_prompts()
         self.__llm = get_llm(streaming=streaming)
 
@@ -379,7 +388,19 @@ def main():
     dotenv.load_dotenv(dotenv.find_dotenv())
 
     streaming = rospy.get_param("~streaming", False)
-    turtle_agent = TurtleAgent(verbose=False, streaming=streaming)
+    obstacle_store: Optional[ObstacleStore] = None
+    path = str(rospy.get_param("~static_obstacles_file", "")).strip()
+    if path:
+        obstacle_store = ObstacleStore()
+        try:
+            load_file(obstacle_store, path)
+        except StaticMapLoadError as e:
+            rospy.logerr("static obstacles: %s", e)
+            raise
+
+    turtle_agent = TurtleAgent(
+        verbose=False, streaming=streaming, obstacle_store=obstacle_store
+    )
 
     try:
         asyncio.run(turtle_agent.run())

--- a/tests/test_turtle_agent/test_static_map_loader.py
+++ b/tests/test_turtle_agent/test_static_map_loader.py
@@ -1,0 +1,217 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "src" / "turtle_agent" / "scripts"
+_CONFIG = _REPO_ROOT / "src" / "turtle_agent" / "config"
+sys.path.insert(0, str(_SCRIPTS))
+
+from obstacle_store import (  # noqa: E402
+    CircleGeometry,
+    ObstacleStore,
+    SegmentsGeometry,
+)
+from static_map_loader import (  # noqa: E402
+    StaticMapLoadError,
+    load_file,
+    load_into_store,
+)
+
+
+class TestStaticMapLoader(unittest.TestCase):
+    def test_load_into_store_circle_and_segments(self):
+        store = ObstacleStore()
+        data = {
+            "obstacles": [
+                {
+                    "id": "p",
+                    "geometry": {"type": "circle", "cx": 1.0, "cy": 2.0, "r": 0.5},
+                },
+                {
+                    "id": "w",
+                    "geometry": {
+                        "type": "segments",
+                        "segments": [[[0.0, 0.0], [1.0, 0.0]]],
+                    },
+                },
+            ]
+        }
+        n = load_into_store(store, data, source="inline")
+        self.assertEqual(n, 2)
+        self.assertEqual(len(store), 2)
+        snap = {o.id: o for o in store.snapshot()}
+        self.assertIsInstance(snap["p"].geometry, CircleGeometry)
+        self.assertEqual(
+            (snap["p"].geometry.cx, snap["p"].geometry.cy, snap["p"].geometry.r),
+            (1.0, 2.0, 0.5),
+        )
+        self.assertIsInstance(snap["w"].geometry, SegmentsGeometry)
+        self.assertEqual(snap["w"].geometry.segments, (((0.0, 0.0), (1.0, 0.0)),))
+
+    def test_on_duplicate_id_error_in_store(self):
+        store = ObstacleStore()
+        load_into_store(
+            store,
+            {
+                "obstacles": [
+                    {
+                        "id": "a",
+                        "geometry": {"type": "circle", "cx": 0, "cy": 0, "r": 1},
+                    }
+                ]
+            },
+        )
+        with self.assertRaises(StaticMapLoadError) as ctx:
+            load_into_store(
+                store,
+                {
+                    "obstacles": [
+                        {
+                            "id": "a",
+                            "geometry": {"type": "circle", "cx": 1, "cy": 1, "r": 1},
+                        }
+                    ]
+                },
+                on_duplicate_id="error",
+            )
+        self.assertIn("already exists", str(ctx.exception))
+
+    def test_on_duplicate_id_error_same_document(self):
+        store = ObstacleStore()
+        with self.assertRaises(StaticMapLoadError) as ctx:
+            load_into_store(
+                store,
+                {
+                    "obstacles": [
+                        {
+                            "id": "a",
+                            "geometry": {"type": "circle", "cx": 0, "cy": 0, "r": 1},
+                        },
+                        {
+                            "id": "a",
+                            "geometry": {"type": "circle", "cx": 1, "cy": 1, "r": 1},
+                        },
+                    ]
+                },
+                on_duplicate_id="error",
+            )
+        self.assertIn("duplicate id", str(ctx.exception))
+
+    def test_replace_overwrites(self):
+        store = ObstacleStore()
+        load_into_store(
+            store,
+            {
+                "obstacles": [
+                    {
+                        "id": "a",
+                        "geometry": {"type": "circle", "cx": 0, "cy": 0, "r": 1},
+                    }
+                ]
+            },
+        )
+        load_into_store(
+            store,
+            {
+                "obstacles": [
+                    {
+                        "id": "a",
+                        "geometry": {"type": "circle", "cx": 5, "cy": 5, "r": 2},
+                    }
+                ]
+            },
+            on_duplicate_id="replace",
+        )
+        o = store.get("a")
+        assert o is not None
+        self.assertEqual(o.geometry.cx, 5.0)
+
+    def test_unknown_geometry_type_message(self):
+        with self.assertRaises(StaticMapLoadError) as ctx:
+            load_into_store(
+                ObstacleStore(),
+                {
+                    "obstacles": [
+                        {
+                            "id": "x",
+                            "geometry": {"type": "nope", "cx": 0, "cy": 0, "r": 1},
+                        }
+                    ]
+                },
+                source="testsrc",
+            )
+        msg = str(ctx.exception)
+        self.assertIn("unknown geometry.type", msg)
+        self.assertIn("testsrc", msg)
+        self.assertIn("index=0", msg)
+
+    def test_load_file_yaml_tmp(self):
+        store = ObstacleStore()
+        doc = {
+            "obstacles": [
+                {"id": "z", "geometry": {"type": "circle", "cx": 0, "cy": 0, "r": 0.25}}
+            ]
+        }
+        with tempfile.NamedTemporaryFile(
+            suffix=".yaml", mode="w", delete=False, encoding="utf-8"
+        ) as f:
+            import yaml as _yaml
+
+            _yaml.safe_dump(doc, f)
+            path = f.name
+        try:
+            n = load_file(store, path)
+            self.assertEqual(n, 1)
+            self.assertIsNotNone(store.get("z"))
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_load_file_json_tmp(self):
+        store = ObstacleStore()
+        doc = {
+            "obstacles": [
+                {"id": "j", "geometry": {"type": "circle", "cx": 3, "cy": 4, "r": 5}}
+            ]
+        }
+        with tempfile.NamedTemporaryFile(
+            suffix=".json", mode="w", delete=False, encoding="utf-8"
+        ) as f:
+            json.dump(doc, f)
+            path = f.name
+        try:
+            load_file(store, path)
+            o = store.get("j")
+            assert o is not None
+            self.assertEqual(o.geometry.r, 5.0)
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_sample_config_repo_path(self):
+        sample = _CONFIG / "static_obstacles_turtlesim.yaml"
+        self.assertTrue(sample.is_file(), msg=f"missing {sample}")
+        store = ObstacleStore()
+        n = load_file(store, sample)
+        self.assertEqual(n, 4)
+        ids = {o.id for o in store.snapshot()}
+        self.assertEqual(ids, {"wall-south", "wall-east", "wall-north", "wall-west"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 내용
- `static_map_loader.py`: YAML/JSON(dict) 파싱 후 `ObstacleStore`에 `kind=static` 적재. `load_into_store`, `load_file`, `load_from_rosparam`, `on_duplicate_id` (replace/error), `StaticMapLoadError`.
- `static_obstacles_turtlesim.yaml`: turtlesim 11×11 경계 샘플.
- `test_static_map_loader.py`: 단위 테스트.
- `turtle_agent.py`: `~static_obstacles_file` 파라미터가 있으면 기동 시 로드 후 `TurtleAgent`에 `_obstacle_store`로 전달.

## 테스트
- `uv run python -m unittest discover -s tests/test_turtle_agent -v` 통과

부모 이슈: #4 (단계 3), 구현 이슈: #3

Made with [Cursor](https://cursor.com)