### PR TITLE
feat: 장애물 API와 초기 월드 빌더를 추가합니다

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ https://github.com/user-attachments/assets/77b97014-6d2e-4123-8d0b-ea0916d93a4e
 
 For detailed instructions on setting up and running the TurtleSim demo, please refer to our [TurtleSim Demo Guide](https://github.com/nasa-jpl/rosa/wiki/Guide:-TurtleSim-Demo) in the Wiki.
 
+### TurtleSim Obstacles
+
+The TurtleSim demo can load static obstacles into an in-process `ObstacleStore`
+before the agent conversation starts. Set `~static_obstacles_file` to a YAML or
+JSON map such as `src/turtle_agent/config/static_obstacles_turtlesim.yaml`.
+
+When `~draw_static_world` is enabled, a startup-only `rospy` world builder reads
+the same store snapshot and draws the static world with a temporary builder
+turtle. Runtime obstacle CRUD is managed through LangChain tools that update the
+same store directly. `static` obstacles remain until removed; `ephemeral`
+obstacles expire after their TTL. No HTTP layer is used for obstacle CRUD or
+initial map injection.
+
 
 ## IsaacSim Extension (Coming Soon)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -139,3 +139,17 @@ The following test categories are included in our testing setup. Further details
   - **Tips:**
     - Test the different system states, such as verbosity and debugging modes.
     - Validate the correct implementation of timing functions.
+
+#### Turtle Agent Obstacles
+
+- **Location:** `./tests/test_turtle_agent`
+- **Purpose:** To verify TurtleSim obstacle infrastructure, including static map loading, `ObstacleStore` TTL behavior, runtime obstacle tools, and world builder render planning.
+- **Running Tests:**
+  - **Manually:**
+    1. Navigate to the project root directory in the command line.
+    2. Execute `uv run python -m unittest discover -s tests/test_turtle_agent -v`.
+    3. The unit tests avoid requiring a live turtlesim process; ROS service calls in the world builder are covered with mocks.
+- **Obstacle Policy:**
+  - Static maps are loaded into the in-process `ObstacleStore`.
+  - Initial world drawing is performed by a startup `rospy` builder, not by the LLM or LangChain tools.
+  - Runtime obstacle CRUD updates the same store through tools. `static` obstacles remain until removed, and `ephemeral` obstacles expire after their TTL. No HTTP API is used.

--- a/src/turtle_agent/config/static_obstacles_turtlesim.yaml
+++ b/src/turtle_agent/config/static_obstacles_turtlesim.yaml
@@ -25,11 +25,32 @@ obstacles:
       type: segments
       segments:
         - [ [ 0.0, 11.0 ], [ 0.0, 0.0 ] ]
-  - id: pond-center
+  - id: wet
     kind: static
     geometry:
       type: aabb
-      min_x: 4.75
-      min_y: 4.75
-      max_x: 6.25
-      max_y: 6.25
+      min_x: 5.0
+      min_y: 4.0
+      max_x: 7.0
+      max_y: 6.0
+  - id: a-point
+    kind: static
+    geometry:
+      type: circle
+      cx: 1.0
+      cy: 5.0
+      r: 0.25
+  - id: b-point
+    kind: static
+    geometry:
+      type: circle
+      cx: 10.0
+      cy: 5.0
+      r: 0.25
+  - id: c-point
+    kind: static
+    geometry:
+      type: circle
+      cx: 6.0
+      cy: 7.0
+      r: 0.25

--- a/src/turtle_agent/config/static_obstacles_turtlesim.yaml
+++ b/src/turtle_agent/config/static_obstacles_turtlesim.yaml
@@ -25,3 +25,11 @@ obstacles:
       type: segments
       segments:
         - [ [ 0.0, 11.0 ], [ 0.0, 0.0 ] ]
+  - id: pond-center
+    kind: static
+    geometry:
+      type: aabb
+      min_x: 4.75
+      min_y: 4.75
+      max_x: 6.25
+      max_y: 6.25

--- a/src/turtle_agent/launch/agent.launch
+++ b/src/turtle_agent/launch/agent.launch
@@ -1,5 +1,9 @@
 <launch>
     <arg name="streaming" default="false" />
+    <arg name="static_obstacles_file" default="$(find turtle_agent)/config/static_obstacles_turtlesim.yaml" />
+    <arg name="draw_static_world" default="true" />
+    <arg name="world_builder_required" default="true" />
+
     <node name="rosa_turtle_agent"
           pkg="turtle_agent"
           type="turtle_agent.py"
@@ -8,5 +12,8 @@
           cwd="node"
           output="screen" >
         <param name="streaming" value="$(arg streaming)" />
+        <param name="static_obstacles_file" value="$(arg static_obstacles_file)" />
+        <param name="draw_static_world" value="$(arg draw_static_world)" />
+        <param name="world_builder_required" value="$(arg world_builder_required)" />
     </node>
 </launch>

--- a/src/turtle_agent/scripts/tools/obstacle.py
+++ b/src/turtle_agent/scripts/tools/obstacle.py
@@ -1,0 +1,228 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""LangChain tools for obstacle CRUD backed by ``ObstacleStore``.
+
+These tools intentionally do not expose HTTP. ``TurtleAgent`` injects the same
+in-process store that static map loading and future collision checks use.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Dict, Optional
+
+from langchain.agents import tool
+
+from obstacle_store import (
+    AabbGeometry,
+    CircleGeometry,
+    Obstacle,
+    ObstacleGeometry,
+    ObstacleStore,
+    SegmentsGeometry,
+)
+
+_STORE: Optional[ObstacleStore] = None
+
+
+class ObstacleToolError(ValueError):
+    """Invalid tool input or missing store configuration."""
+
+
+def configure_obstacle_store(store: ObstacleStore) -> None:
+    """Inject the process-local store used by obstacle tools."""
+    global _STORE
+    _STORE = store
+
+
+def _require_store() -> ObstacleStore:
+    if _STORE is None:
+        raise ObstacleToolError("ObstacleStore is not configured.")
+    return _STORE
+
+
+def _coerce_float(value: Any, key: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ObstacleToolError(f"{key} must be a number.")
+    return float(value)
+
+
+def _parse_geometry_json(geometry_json: str) -> ObstacleGeometry:
+    try:
+        raw = json.loads(geometry_json)
+    except json.JSONDecodeError as e:
+        raise ObstacleToolError(f"Invalid geometry_json: {e}") from e
+    if not isinstance(raw, dict):
+        raise ObstacleToolError("geometry_json must decode to a JSON object.")
+    return _parse_geometry(raw)
+
+
+def _parse_geometry(raw: Dict[str, Any]) -> ObstacleGeometry:
+    gtype = raw.get("type")
+    if not isinstance(gtype, str):
+        raise ObstacleToolError("geometry.type must be a string.")
+    gtype_l = gtype.strip().lower()
+    if gtype_l == "circle":
+        for key in ("cx", "cy", "r"):
+            if key not in raw:
+                raise ObstacleToolError(f"geometry.{key} is required for circle.")
+        return CircleGeometry(
+            _coerce_float(raw["cx"], "cx"),
+            _coerce_float(raw["cy"], "cy"),
+            _coerce_float(raw["r"], "r"),
+        )
+    if gtype_l == "aabb":
+        for key in ("min_x", "min_y", "max_x", "max_y"):
+            if key not in raw:
+                raise ObstacleToolError(f"geometry.{key} is required for aabb.")
+        return AabbGeometry(
+            _coerce_float(raw["min_x"], "min_x"),
+            _coerce_float(raw["min_y"], "min_y"),
+            _coerce_float(raw["max_x"], "max_x"),
+            _coerce_float(raw["max_y"], "max_y"),
+        )
+    if gtype_l == "segments":
+        segments = raw.get("segments")
+        if not isinstance(segments, list):
+            raise ObstacleToolError("geometry.segments must be a list.")
+        parsed = []
+        for i, seg in enumerate(segments):
+            if not isinstance(seg, list) or len(seg) != 2:
+                raise ObstacleToolError(f"segments[{i}] must be [p1, p2].")
+            p1, p2 = seg
+            if not isinstance(p1, list) or len(p1) != 2:
+                raise ObstacleToolError(f"segments[{i}][0] must be [x, y].")
+            if not isinstance(p2, list) or len(p2) != 2:
+                raise ObstacleToolError(f"segments[{i}][1] must be [x, y].")
+            parsed.append(
+                (
+                    (_coerce_float(p1[0], "x1"), _coerce_float(p1[1], "y1")),
+                    (_coerce_float(p2[0], "x2"), _coerce_float(p2[1], "y2")),
+                )
+            )
+        return SegmentsGeometry(tuple(parsed))
+    raise ObstacleToolError(
+        f"unknown geometry.type {gtype!r}; expected circle, aabb, or segments."
+    )
+
+
+def _geometry_to_dict(geometry: ObstacleGeometry) -> Dict[str, Any]:
+    if isinstance(geometry, CircleGeometry):
+        return {"type": "circle", "cx": geometry.cx, "cy": geometry.cy, "r": geometry.r}
+    if isinstance(geometry, AabbGeometry):
+        return {
+            "type": "aabb",
+            "min_x": geometry.min_x,
+            "min_y": geometry.min_y,
+            "max_x": geometry.max_x,
+            "max_y": geometry.max_y,
+        }
+    return {
+        "type": "segments",
+        "segments": [[[x1, y1], [x2, y2]] for (x1, y1), (x2, y2) in geometry.segments],
+    }
+
+
+@tool
+def add_obstacle(
+    obstacle_id: str,
+    geometry_json: str,
+    kind: str = "static",
+    ttl_seconds: float = 0.0,
+) -> str:
+    """
+    Add or replace an obstacle in the shared ObstacleStore.
+
+    ``geometry_json`` uses the same shape as static map ``geometry`` entries:
+    ``{"type":"circle","cx":1,"cy":2,"r":0.5}``,
+    ``{"type":"aabb","min_x":1,"min_y":1,"max_x":2,"max_y":2}``, or
+    ``{"type":"segments","segments":[[[0,0],[1,0]]]}``.
+
+    ``kind`` is ``static`` for an obstacle that remains until removed, or
+    ``ephemeral`` for a temporary obstacle that expires after ``ttl_seconds``.
+    """
+    try:
+        oid = obstacle_id.strip()
+        if not oid:
+            raise ObstacleToolError("obstacle_id must be a non-empty string.")
+        kind_l = kind.strip().lower()
+        if kind_l not in ("static", "ephemeral"):
+            raise ObstacleToolError("kind must be 'static' or 'ephemeral'.")
+        expires_at = None
+        if kind_l == "ephemeral":
+            ttl = _coerce_float(ttl_seconds, "ttl_seconds")
+            if ttl <= 0:
+                raise ObstacleToolError(
+                    "ttl_seconds must be positive for ephemeral obstacles."
+                )
+            expires_at = time.monotonic() + ttl
+        geometry = _parse_geometry_json(geometry_json)
+        _require_store().upsert(
+            Obstacle(
+                id=oid,
+                kind=kind_l,
+                geometry=geometry,
+                expires_at=expires_at,
+            )
+        )
+        if kind_l == "ephemeral":
+            return f"Added ephemeral obstacle '{oid}' with ttl_seconds={ttl}."
+        return f"Added static obstacle '{oid}'."
+    except (ObstacleToolError, ValueError) as e:
+        return f"Failed to add obstacle: {e}"
+
+
+@tool
+def remove_obstacle(obstacle_id: str) -> str:
+    """Remove an obstacle by id from the shared ObstacleStore."""
+    try:
+        oid = obstacle_id.strip()
+        if not oid:
+            raise ObstacleToolError("obstacle_id must be a non-empty string.")
+        removed = _require_store().remove(oid)
+        if removed:
+            return f"Removed obstacle '{oid}'."
+        return f"Obstacle '{oid}' was not found."
+    except ObstacleToolError as e:
+        return f"Failed to remove obstacle: {e}"
+
+
+@tool
+def list_obstacles(include_expired: bool = False) -> str:
+    """List current obstacles from the shared ObstacleStore as JSON."""
+    try:
+        if include_expired:
+            return (
+                "Expired obstacles cannot be listed because ObstacleStore purges "
+                "them during reads."
+            )
+        rows = []
+        now = time.monotonic()
+        for obstacle in _require_store().snapshot():
+            expires_in = None
+            if obstacle.expires_at is not None:
+                expires_in = max(0.0, obstacle.expires_at - now)
+            rows.append(
+                {
+                    "id": obstacle.id,
+                    "kind": obstacle.kind,
+                    "expires_in_seconds": expires_in,
+                    "geometry": _geometry_to_dict(obstacle.geometry),
+                }
+            )
+        return json.dumps({"obstacles": rows}, ensure_ascii=False, sort_keys=True)
+    except ObstacleToolError as e:
+        return f"Failed to list obstacles: {e}"

--- a/src/turtle_agent/scripts/turtle_agent.py
+++ b/src/turtle_agent/scripts/turtle_agent.py
@@ -36,12 +36,14 @@ from rich.text import Text
 from rosa import ROSA
 
 import tools.turtle as turtle_tools
+import tools.obstacle as obstacle_tools
 from help import get_help
 from obstacle_store import ObstacleStore
 from pose_logger import PoseLogger
 from llm import get_llm
 from prompts import get_prompts
 from static_map_loader import StaticMapLoadError, load_file
+from world_builder import draw_static_world
 
 
 def _maybe_attach_debugpy() -> None:
@@ -110,7 +112,8 @@ class TurtleAgent(ROSA):
         obstacle_store: Optional[ObstacleStore] = None,
     ):
         self.__blacklist = ["master", "docker"]
-        self._obstacle_store = obstacle_store
+        self._obstacle_store = obstacle_store or ObstacleStore()
+        obstacle_tools.configure_obstacle_store(self._obstacle_store)
         self.__prompts = get_prompts()
         self.__llm = get_llm(streaming=streaming)
 
@@ -134,7 +137,7 @@ class TurtleAgent(ROSA):
             ros_version=1,
             llm=self.__llm,
             tools=[cool_turtle_tool, blast_off],
-            tool_packages=[turtle_tools],
+            tool_packages=[turtle_tools, obstacle_tools],
             blacklist=self.__blacklist,
             prompts=self.__prompts,
             verbose=verbose,
@@ -388,15 +391,22 @@ def main():
     dotenv.load_dotenv(dotenv.find_dotenv())
 
     streaming = rospy.get_param("~streaming", False)
-    obstacle_store: Optional[ObstacleStore] = None
+    obstacle_store = ObstacleStore()
     path = str(rospy.get_param("~static_obstacles_file", "")).strip()
     if path:
-        obstacle_store = ObstacleStore()
         try:
             load_file(obstacle_store, path)
         except StaticMapLoadError as e:
             rospy.logerr("static obstacles: %s", e)
             raise
+        if rospy.get_param("~draw_static_world", True):
+            try:
+                count = draw_static_world(obstacle_store)
+                rospy.loginfo("static world builder drew %s segments", count)
+            except Exception as e:
+                rospy.logerr("static world builder failed: %s", e)
+                if rospy.get_param("~world_builder_required", True):
+                    raise
 
     turtle_agent = TurtleAgent(
         verbose=False, streaming=streaming, obstacle_store=obstacle_store

--- a/src/turtle_agent/scripts/world_builder.py
+++ b/src/turtle_agent/scripts/world_builder.py
@@ -1,0 +1,158 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Draw static obstacles in turtlesim from an ``ObstacleStore`` snapshot.
+
+This module is deliberately not a LangChain tool. It is called once during node
+startup after static map loading and before the agent conversation begins.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+
+from obstacle_store import (
+    AabbGeometry,
+    CircleGeometry,
+    Obstacle,
+    ObstacleStore,
+    SegmentsGeometry,
+)
+
+
+@dataclass(frozen=True)
+class RenderSegment:
+    x1: float
+    y1: float
+    x2: float
+    y2: float
+
+
+def render_segments_from_store(
+    store: ObstacleStore, *, circle_segments: int = 24
+) -> Tuple[RenderSegment, ...]:
+    """Return line segments for all non-expired obstacles in ``store``."""
+    return render_segments_from_obstacles(
+        store.snapshot(), circle_segments=circle_segments
+    )
+
+
+def render_segments_from_obstacles(
+    obstacles: Iterable[Obstacle], *, circle_segments: int = 24
+) -> Tuple[RenderSegment, ...]:
+    """Convert obstacle geometry to line segments that a builder turtle can draw."""
+    segments = []
+    for obstacle in obstacles:
+        segments.extend(
+            _segments_for_obstacle(obstacle, circle_segments=circle_segments)
+        )
+    return tuple(segments)
+
+
+def _segments_for_obstacle(
+    obstacle: Obstacle, *, circle_segments: int
+) -> Tuple[RenderSegment, ...]:
+    geometry = obstacle.geometry
+    if isinstance(geometry, SegmentsGeometry):
+        return tuple(
+            RenderSegment(x1, y1, x2, y2) for (x1, y1), (x2, y2) in geometry.segments
+        )
+    if isinstance(geometry, AabbGeometry):
+        min_x, min_y = geometry.min_x, geometry.min_y
+        max_x, max_y = geometry.max_x, geometry.max_y
+        return (
+            RenderSegment(min_x, min_y, max_x, min_y),
+            RenderSegment(max_x, min_y, max_x, max_y),
+            RenderSegment(max_x, max_y, min_x, max_y),
+            RenderSegment(min_x, max_y, min_x, min_y),
+        )
+    if circle_segments < 3:
+        raise ValueError("circle_segments must be >= 3")
+    points = []
+    for i in range(circle_segments):
+        theta = 2.0 * math.pi * i / circle_segments
+        points.append(
+            (
+                geometry.cx + geometry.r * math.cos(theta),
+                geometry.cy + geometry.r * math.sin(theta),
+            )
+        )
+    return tuple(
+        RenderSegment(x1, y1, x2, y2)
+        for (x1, y1), (x2, y2) in zip(points, points[1:] + points[:1])
+    )
+
+
+def draw_static_world(
+    store: ObstacleStore,
+    *,
+    turtle_name: str = "world_builder",
+    circle_segments: int = 24,
+    pen_rgb: Tuple[int, int, int] = (40, 40, 40),
+    pen_width: int = 2,
+    service_timeout: float = 5.0,
+) -> int:
+    """Draw the current store snapshot with a temporary builder turtle.
+
+    Returns the number of line segments drawn. The builder turtle is removed on
+    exit when possible.
+    """
+    import rospy
+    from turtlesim.srv import Kill, SetPen, Spawn, TeleportAbsolute
+
+    segments = render_segments_from_store(store, circle_segments=circle_segments)
+    if not segments:
+        return 0
+
+    first = segments[0]
+    turtle_name = turtle_name.replace("/", "")
+
+    rospy.wait_for_service("/spawn", timeout=service_timeout)
+    spawn = rospy.ServiceProxy("/spawn", Spawn)
+    kill = rospy.ServiceProxy("/kill", Kill)
+
+    def kill_builder() -> None:
+        try:
+            rospy.wait_for_service("/kill", timeout=service_timeout)
+            kill(turtle_name)
+        except Exception:
+            pass
+
+    # Avoid a stale builder from a previous run blocking spawn.
+    kill_builder()
+    spawn(x=first.x1, y=first.y1, theta=0.0, name=turtle_name)
+
+    set_pen = rospy.ServiceProxy(f"/{turtle_name}/set_pen", SetPen)
+    teleport = rospy.ServiceProxy(f"/{turtle_name}/teleport_absolute", TeleportAbsolute)
+    try:
+        rospy.wait_for_service(f"/{turtle_name}/set_pen", timeout=service_timeout)
+        rospy.wait_for_service(
+            f"/{turtle_name}/teleport_absolute", timeout=service_timeout
+        )
+        for segment in segments:
+            set_pen(r=0, g=0, b=0, width=pen_width, off=1)
+            teleport(x=segment.x1, y=segment.y1, theta=0.0)
+            set_pen(
+                r=int(pen_rgb[0]),
+                g=int(pen_rgb[1]),
+                b=int(pen_rgb[2]),
+                width=pen_width,
+                off=0,
+            )
+            teleport(x=segment.x2, y=segment.y2, theta=0.0)
+        return len(segments)
+    finally:
+        kill_builder()

--- a/tests/test_turtle_agent/test_obstacle_tools.py
+++ b/tests/test_turtle_agent/test_obstacle_tools.py
@@ -1,0 +1,102 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import json
+import sys
+import time
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "src" / "turtle_agent" / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+from obstacle_store import AabbGeometry, ObstacleStore  # noqa: E402
+from tools import obstacle as obstacle_tools  # noqa: E402
+
+
+class TestObstacleTools(unittest.TestCase):
+    def setUp(self):
+        self.store = ObstacleStore()
+        obstacle_tools.configure_obstacle_store(self.store)
+
+    def test_add_list_remove_static_obstacle(self):
+        geometry_json = json.dumps(
+            {"type": "aabb", "min_x": 1, "min_y": 2, "max_x": 3, "max_y": 4}
+        )
+        out = obstacle_tools.add_obstacle.invoke(
+            {
+                "obstacle_id": "pond",
+                "geometry_json": geometry_json,
+                "kind": "static",
+            }
+        )
+        self.assertIn("Added static obstacle", out)
+
+        obstacle = self.store.get("pond")
+        self.assertIsNotNone(obstacle)
+        assert obstacle is not None
+        self.assertEqual(obstacle.kind, "static")
+        self.assertIsInstance(obstacle.geometry, AabbGeometry)
+
+        listed = json.loads(obstacle_tools.list_obstacles.invoke({}))
+        self.assertEqual(listed["obstacles"][0]["id"], "pond")
+
+        removed = obstacle_tools.remove_obstacle.invoke({"obstacle_id": "pond"})
+        self.assertIn("Removed obstacle", removed)
+        self.assertIsNone(self.store.get("pond"))
+
+    def test_add_rejects_invalid_geometry(self):
+        out = obstacle_tools.add_obstacle.invoke(
+            {
+                "obstacle_id": "bad",
+                "geometry_json": json.dumps({"type": "unknown"}),
+                "kind": "static",
+            }
+        )
+        self.assertIn("Failed to add obstacle", out)
+        self.assertEqual(len(self.store), 0)
+
+    def test_add_ephemeral_rejects_non_positive_ttl(self):
+        out = obstacle_tools.add_obstacle.invoke(
+            {
+                "obstacle_id": "bad",
+                "geometry_json": json.dumps(
+                    {"type": "circle", "cx": 0, "cy": 0, "r": 1}
+                ),
+                "kind": "ephemeral",
+                "ttl_seconds": 0,
+            }
+        )
+        self.assertIn("ttl_seconds must be positive for ephemeral obstacles", out)
+        self.assertEqual(len(self.store), 0)
+
+    def test_ephemeral_expires_from_tool_listing(self):
+        obstacle_tools.add_obstacle.invoke(
+            {
+                "obstacle_id": "short",
+                "geometry_json": json.dumps(
+                    {"type": "circle", "cx": 0, "cy": 0, "r": 1}
+                ),
+                "kind": "ephemeral",
+                "ttl_seconds": 0.01,
+            }
+        )
+        time.sleep(0.03)
+        listed = json.loads(obstacle_tools.list_obstacles.invoke({}))
+        self.assertEqual(listed["obstacles"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_turtle_agent/test_static_map_loader.py
+++ b/tests/test_turtle_agent/test_static_map_loader.py
@@ -208,11 +208,20 @@ class TestStaticMapLoader(unittest.TestCase):
         self.assertTrue(sample.is_file(), msg=f"missing {sample}")
         store = ObstacleStore()
         n = load_file(store, sample)
-        self.assertEqual(n, 5)
+        self.assertEqual(n, 8)
         ids = {o.id for o in store.snapshot()}
         self.assertEqual(
             ids,
-            {"wall-south", "wall-east", "wall-north", "wall-west", "pond-center"},
+            {
+                "wall-south",
+                "wall-east",
+                "wall-north",
+                "wall-west",
+                "wet",
+                "a-point",
+                "b-point",
+                "c-point",
+            },
         )
 
 

--- a/tests/test_turtle_agent/test_static_map_loader.py
+++ b/tests/test_turtle_agent/test_static_map_loader.py
@@ -208,9 +208,12 @@ class TestStaticMapLoader(unittest.TestCase):
         self.assertTrue(sample.is_file(), msg=f"missing {sample}")
         store = ObstacleStore()
         n = load_file(store, sample)
-        self.assertEqual(n, 4)
+        self.assertEqual(n, 5)
         ids = {o.id for o in store.snapshot()}
-        self.assertEqual(ids, {"wall-south", "wall-east", "wall-north", "wall-west"})
+        self.assertEqual(
+            ids,
+            {"wall-south", "wall-east", "wall-north", "wall-west", "pond-center"},
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_turtle_agent/test_world_builder.py
+++ b/tests/test_turtle_agent/test_world_builder.py
@@ -1,0 +1,160 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "src" / "turtle_agent" / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+from obstacle_store import (  # noqa: E402
+    AabbGeometry,
+    CircleGeometry,
+    Obstacle,
+    ObstacleStore,
+    SegmentsGeometry,
+)
+from world_builder import (  # noqa: E402
+    RenderSegment,
+    draw_static_world,
+    render_segments_from_obstacles,
+)
+
+
+class TestWorldBuilderRenderSegments(unittest.TestCase):
+    def test_segments_geometry_passes_through(self):
+        obstacles = [
+            Obstacle(
+                "wall",
+                "static",
+                SegmentsGeometry((((0.0, 0.0), (1.0, 0.0)),)),
+                None,
+            )
+        ]
+        self.assertEqual(
+            render_segments_from_obstacles(obstacles),
+            (RenderSegment(0.0, 0.0, 1.0, 0.0),),
+        )
+
+    def test_aabb_becomes_four_edges(self):
+        obstacles = [Obstacle("box", "static", AabbGeometry(1.0, 2.0, 3.0, 4.0), None)]
+        self.assertEqual(
+            render_segments_from_obstacles(obstacles),
+            (
+                RenderSegment(1.0, 2.0, 3.0, 2.0),
+                RenderSegment(3.0, 2.0, 3.0, 4.0),
+                RenderSegment(3.0, 4.0, 1.0, 4.0),
+                RenderSegment(1.0, 4.0, 1.0, 2.0),
+            ),
+        )
+
+    def test_circle_becomes_closed_polygon(self):
+        obstacles = [Obstacle("circle", "static", CircleGeometry(0.0, 0.0, 1.0), None)]
+        segments = render_segments_from_obstacles(obstacles, circle_segments=4)
+        self.assertEqual(len(segments), 4)
+        self.assertAlmostEqual(segments[0].x1, 1.0)
+        self.assertAlmostEqual(segments[-1].x2, 1.0)
+        self.assertAlmostEqual(segments[-1].y2, 0.0)
+
+
+class TestWorldBuilderRosCalls(unittest.TestCase):
+    def test_draw_static_world_uses_builder_turtle_and_cleanup(self):
+        calls = []
+
+        class FakeRospy(types.ModuleType):
+            def wait_for_service(self, name, timeout=5.0):
+                calls.append(("wait", name, timeout))
+
+            def ServiceProxy(self, name, service_type):
+                def proxy(*args, **kwargs):
+                    calls.append(("call", name, args, kwargs))
+
+                return proxy
+
+        turtlesim = types.ModuleType("turtlesim")
+        turtlesim_srv = types.ModuleType("turtlesim.srv")
+        turtlesim_srv.Kill = object
+        turtlesim_srv.SetPen = object
+        turtlesim_srv.Spawn = object
+        turtlesim_srv.TeleportAbsolute = object
+        turtlesim.srv = turtlesim_srv
+
+        old_rospy = sys.modules.get("rospy")
+        old_turtlesim = sys.modules.get("turtlesim")
+        old_turtlesim_srv = sys.modules.get("turtlesim.srv")
+        sys.modules["rospy"] = FakeRospy("rospy")
+        sys.modules["turtlesim"] = turtlesim
+        sys.modules["turtlesim.srv"] = turtlesim_srv
+        try:
+            store = ObstacleStore()
+            store.upsert(
+                Obstacle(
+                    "wall",
+                    "static",
+                    SegmentsGeometry((((0.0, 0.0), (1.0, 0.0)),)),
+                    None,
+                )
+            )
+            count = draw_static_world(store, turtle_name="builder", service_timeout=1.0)
+        finally:
+            if old_rospy is None:
+                sys.modules.pop("rospy", None)
+            else:
+                sys.modules["rospy"] = old_rospy
+            if old_turtlesim is None:
+                sys.modules.pop("turtlesim", None)
+            else:
+                sys.modules["turtlesim"] = old_turtlesim
+            if old_turtlesim_srv is None:
+                sys.modules.pop("turtlesim.srv", None)
+            else:
+                sys.modules["turtlesim.srv"] = old_turtlesim_srv
+
+        self.assertEqual(count, 1)
+        self.assertIn(
+            (
+                "call",
+                "/spawn",
+                (),
+                {"x": 0.0, "y": 0.0, "theta": 0.0, "name": "builder"},
+            ),
+            calls,
+        )
+        self.assertIn(
+            (
+                "call",
+                "/builder/set_pen",
+                (),
+                {"r": 0, "g": 0, "b": 0, "width": 2, "off": 1},
+            ),
+            calls,
+        )
+        self.assertIn(
+            (
+                "call",
+                "/builder/teleport_absolute",
+                (),
+                {"x": 1.0, "y": 0.0, "theta": 0.0},
+            ),
+            calls,
+        )
+        kill_calls = [c for c in calls if c[0] == "call" and c[1] == "/kill"]
+        self.assertEqual(len(kill_calls), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 내용
- `ObstacleStore`를 기준으로 장애물을 추가·삭제·조회하는 범용 LangChain Tool을 추가했습니다.
- `TurtleAgent`가 하나의 `ObstacleStore`를 정적 맵 로더, 장애물 Tool, 초기 월드 빌더에 공유하도록 연결했습니다.
- `world_builder.py`를 추가해 정적 장애물을 LLM/Tool 경유 없이 `rospy` 빌더 거북이로 초기 렌더링합니다.
- turtlesim 정적 맵 예시에 사방 벽(`segments`)과 중앙 웅덩이(`aabb`)를 포함했습니다.
- 장애물 Tool, 월드 빌더, 정적 맵 샘플 테스트 및 README/TESTING 문서를 보강했습니다.

## 설계 메모
- HTTP API는 추가하지 않았습니다.
- `add_obstacle`은 범용 추가 Tool입니다.
- `kind="static"` 장애물은 명시적으로 삭제할 때까지 유지되고, `kind="ephemeral"` 장애물은 `ttl_seconds` 이후 Store 조회 시 자동 만료됩니다.
- 초기 월드 렌더링은 에이전트 대화 시작 전에 `world_builder.py`가 Store snapshot을 읽어 수행합니다.

## 테스트
- [x] `uv run python -m unittest tests.test_turtle_agent.test_obstacle_tools tests.test_turtle_agent.test_world_builder tests.test_turtle_agent.test_static_map_loader -v`
- 결과: 16 tests OK

## 관련 이슈
- Closes #9
- Parent: #4

Made with [Cursor](https://cursor.com)