### PR TITLE
fix(demo): macOS Docker DISPLAY를 host.docker.internal 기준으로 복구

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -41,7 +41,9 @@ case "$(uname)" in
         # Keep XQuartz's DISPLAY or default to :0
         export DISPLAY=${DISPLAY:-:0}
         xhost +local:docker &>/dev/null || true
-        
+        # host.docker.internal X clients may appear as localhost on the host
+        xhost +localhost &>/dev/null || true
+
         # Check if XQuartz is running and properly configured
         if ! pgrep -xq "Xquartz" && ! pgrep -xq "X11"; then
             echo "Error: XQuartz is not running. Please start XQuartz and try again."
@@ -82,10 +84,13 @@ echo "Running the Docker container..."
 # Remote debug: export ROSA_DEBUGPY=1 before running; macOS publishes debugpy port to the host.
 DEBUGPY_PORT="${ROSA_DEBUGPY_PORT:-5678}"
 if [ "$(uname)" = "Darwin" ]; then
+    # macOS: LAN IP in DISPLAY often does not route from the Linux VM; use
+    # host.docker.internal. Override: ROSA_DOCKER_DISPLAY=host.example.com:0 ./demo.sh
+    DOCKER_DISPLAY="${ROSA_DOCKER_DISPLAY:-host.docker.internal:0}"
     # macOS: Use host.docker.internal for X11
     docker run -it --rm --init --name $CONTAINER_NAME \
         -p "${DEBUGPY_PORT}:${DEBUGPY_PORT}" \
-        -e DISPLAY=192.168.38.39:0 \
+        -e DISPLAY="$DOCKER_DISPLAY" \
         -e HEADLESS=$HEADLESS \
         -e DEVELOPMENT=$DEVELOPMENT \
         -e ROSA_DEBUGPY="${ROSA_DEBUGPY:-}" \


### PR DESCRIPTION
## 변경 내용
- macOS `docker run`의 `DISPLAY` 기본값을 `host.docker.internal:0`으로 두고, `ROSA_DOCKER_DISPLAY` 환경 변수로 오버라이드 가능
- Darwin 구간에 `xhost +localhost` 추가 (Docker 클라이언트가 localhost로 보일 때 대비)

## 배경
PR #2 적용 시 LAN IP 하드코딩으로 Docker Desktop에서 XQuartz 연결이 실패할 수 있음 (이슈 #11).

Fixes #11

## 테스트
- [x] macOS + Docker Desktop + XQuartz에서 `./demo.sh`로 Turtlesim GUI 확인
- [x] `ROSA_DEBUGPY=1 ./demo.sh` 경로 회귀 확인(선택)

Made with [Cursor](https://cursor.com)