### PR TITLE
chore: .gitignore에 .specstory 무시 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 .DS_Store
 .env
 logs/
+.specstory


### PR DESCRIPTION
## 요약
`.specstory` 디렉터리를 무시하도록 `.gitignore`를 수정합니다.

## 관련 이슈
Closes #13

## 변경
- `.gitignore`: `.specstory` 항목 1줄 추가

## 테스트
- 별도 테스트 없음(무시 규칙만 추가).

Made with [Cursor](https://cursor.com)