### PR TITLE
feat: PoseHub 기반 다중 거북이 pose 추적 및 로깅 통합

### DIFF
--- a/src/turtle_agent/scripts/pose_hub.py
+++ b/src/turtle_agent/scripts/pose_hub.py
@@ -1,0 +1,173 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Shared turtlesim pose subscriptions with fan-out to in-process consumers."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+POSE_TOPIC_TYPE = "turtlesim/Pose"
+
+PoseConsumer = Callable[[str, Any, Any], None]
+SubscriberFactory = Callable[[str, Callable[[Any], None]], Any]
+TopicProvider = Callable[[], Iterable[Tuple[str, str]]]
+TimeSource = Callable[[], Any]
+
+
+def normalize_turtle_name(name: str) -> str:
+    """Return a ROS namespace-friendly turtle name without slashes."""
+    return str(name).strip().replace("/", "")
+
+
+def extract_turtle_name_from_pose_topic(topic: str, topic_type: str) -> Optional[str]:
+    """Extract ``name`` from a top-level ``/name/pose`` turtlesim Pose topic."""
+    if topic_type not in (POSE_TOPIC_TYPE, "turtlesim/msg/Pose"):
+        return None
+    parts = str(topic).strip().split("/")
+    if len(parts) != 3 or parts[0] != "" or parts[2] != "pose":
+        return None
+    name = normalize_turtle_name(parts[1])
+    if not name:
+        return None
+    return name
+
+
+class PoseHub:
+    """Manage one ``/{name}/pose`` subscriber per turtle and notify consumers."""
+
+    def __init__(
+        self,
+        *,
+        subscriber_factory: Optional[SubscriberFactory] = None,
+        topic_provider: Optional[TopicProvider] = None,
+        time_source: Optional[TimeSource] = None,
+    ) -> None:
+        self._lock = threading.RLock()
+        self._subscribers: Dict[str, Any] = {}
+        self._latest_poses: Dict[str, Tuple[Any, Any]] = {}
+        self._consumers: List[PoseConsumer] = []
+        self._subscriber_factory = subscriber_factory
+        self._topic_provider = topic_provider
+        self._time_source = time_source
+        self._stopped = False
+
+    def register_consumer(self, consumer: PoseConsumer) -> None:
+        """Register a callback receiving ``(turtle_name, pose, stamp)``."""
+        with self._lock:
+            if consumer not in self._consumers:
+                self._consumers.append(consumer)
+
+    def unregister_consumer(self, consumer: PoseConsumer) -> None:
+        with self._lock:
+            self._consumers = [c for c in self._consumers if c != consumer]
+
+    def start_from_ros_graph_once(self) -> Tuple[str, ...]:
+        """Scan current ROS topics once and register all turtlesim pose topics."""
+        registered = []
+        for topic, topic_type in self._get_published_topics():
+            name = extract_turtle_name_from_pose_topic(topic, topic_type)
+            if name and self.register_turtle(name):
+                registered.append(name)
+        return tuple(registered)
+
+    def register_turtle(self, name: str) -> bool:
+        """Subscribe to ``/{name}/pose`` if not already registered."""
+        turtle_name = normalize_turtle_name(name)
+        if not turtle_name:
+            raise ValueError("turtle name must be non-empty")
+
+        with self._lock:
+            if self._stopped:
+                raise RuntimeError("PoseHub is stopped")
+            if turtle_name in self._subscribers:
+                return False
+
+            topic = f"/{turtle_name}/pose"
+            self._subscribers[turtle_name] = self._make_subscriber(
+                topic, self._make_pose_callback(turtle_name)
+            )
+            return True
+
+    def unregister_turtle(self, name: str) -> bool:
+        """Unsubscribe and forget latest pose for ``name``."""
+        turtle_name = normalize_turtle_name(name)
+        with self._lock:
+            sub = self._subscribers.pop(turtle_name, None)
+            self._latest_poses.pop(turtle_name, None)
+        if sub is None:
+            return False
+        unregister = getattr(sub, "unregister", None)
+        if callable(unregister):
+            unregister()
+        return True
+
+    def snapshot(self) -> Dict[str, Tuple[Any, Any]]:
+        """Return ``{name: (pose, stamp)}`` for the latest known poses."""
+        with self._lock:
+            return dict(self._latest_poses)
+
+    def stop(self) -> None:
+        with self._lock:
+            self._stopped = True
+            subscribers = tuple(self._subscribers.values())
+            self._subscribers.clear()
+            self._latest_poses.clear()
+            self._consumers.clear()
+        for sub in subscribers:
+            unregister = getattr(sub, "unregister", None)
+            if callable(unregister):
+                unregister()
+
+    def on_turtle_spawned(self, name: str) -> None:
+        self.register_turtle(name)
+
+    def on_turtle_killed(self, name: str) -> None:
+        self.unregister_turtle(name)
+
+    def _make_pose_callback(self, turtle_name: str) -> Callable[[Any], None]:
+        def _on_pose(msg: Any) -> None:
+            stamp = self._now()
+            with self._lock:
+                if self._stopped or turtle_name not in self._subscribers:
+                    return
+                self._latest_poses[turtle_name] = (msg, stamp)
+                consumers = tuple(self._consumers)
+            for consumer in consumers:
+                consumer(turtle_name, msg, stamp)
+
+        return _on_pose
+
+    def _make_subscriber(self, topic: str, callback: Callable[[Any], None]) -> Any:
+        if self._subscriber_factory is not None:
+            return self._subscriber_factory(topic, callback)
+        import rospy
+        from turtlesim.msg import Pose
+
+        return rospy.Subscriber(topic, Pose, callback, queue_size=1)
+
+    def _get_published_topics(self) -> Iterable[Tuple[str, str]]:
+        if self._topic_provider is not None:
+            return self._topic_provider()
+        import rospy
+
+        return rospy.get_published_topics()
+
+    def _now(self) -> Any:
+        if self._time_source is not None:
+            return self._time_source()
+        import rospy
+
+        return rospy.Time.now()

--- a/src/turtle_agent/scripts/pose_logger.py
+++ b/src/turtle_agent/scripts/pose_logger.py
@@ -12,13 +12,18 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-"""Periodic turtlesim pose logging to JSONL (ROS 1 / rospy only in PoseLogger)."""
+"""Periodic turtlesim pose logging to JSONL.
+
+The pure helpers and :class:`PoseLogConsumer` are ROS-free at import time. ROS 1
+imports are delayed to runtime wrappers so unit tests can run without turtlesim.
+"""
 
 from __future__ import annotations
 
 import json
 import os
 import threading
+import time
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -38,8 +43,15 @@ def resolve_log_root() -> Path:
 def build_log_dir(
     log_root: Path, date_str: str, session_id: str, turtle_id: str
 ) -> Path:
-    """logs/<date>/location/<session>/<turtle>/"""
-    return log_root / date_str / "location" / session_id / turtle_id
+    """logs/<date>/<session>/<turtle>/"""
+    return log_root / date_str / session_id / turtle_id
+
+
+def build_location_log_path(
+    log_root: Path, date_str: str, session_id: str, turtle_id: str
+) -> Path:
+    """Return ``logs/<date>/<session>/<turtle>/location.jsonl``."""
+    return build_log_dir(log_root, date_str, session_id, turtle_id) / "location.jsonl"
 
 
 def pose_to_record(pose: Any, stamp: Any) -> Dict[str, Any]:
@@ -62,9 +74,100 @@ def pose_to_record(pose: Any, stamp: Any) -> Dict[str, Any]:
     }
 
 
+def _stamp_to_seconds(stamp: Any) -> float:
+    if hasattr(stamp, "secs"):
+        return float(stamp.secs) + float(stamp.nsecs) / 1_000_000_000.0
+    if isinstance(stamp, dict) and "secs" in stamp and "nsecs" in stamp:
+        return float(stamp["secs"]) + float(stamp["nsecs"]) / 1_000_000_000.0
+    return time.monotonic()
+
+
+class PoseLogConsumer:
+    """PoseHub consumer that writes one ``location.jsonl`` file per turtle."""
+
+    def __init__(
+        self,
+        *,
+        period: float = POSE_LOG_INTERVAL_SEC,
+        log_root: Optional[Path] = None,
+        session_id: Optional[str] = None,
+        date_str: Optional[str] = None,
+    ) -> None:
+        self._period = float(period)
+        self._log_root = log_root or resolve_log_root()
+        self._session_id = session_id or str(uuid.uuid4())
+        self._date_str = date_str or datetime.now().strftime("%Y-%m-%d")
+        self._lock = threading.Lock()
+        self._files: Dict[str, TextIO] = {}
+        self._paths: Dict[str, Path] = {}
+        self._last_written_at: Dict[str, float] = {}
+        self._closed = False
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    def path_for(self, turtle_id: str) -> Path:
+        turtle_id = str(turtle_id).replace("/", "")
+        return build_location_log_path(
+            self._log_root, self._date_str, self._session_id, turtle_id
+        )
+
+    def on_pose(self, turtle_id: str, pose: Any, stamp: Any) -> None:
+        stamp_seconds = _stamp_to_seconds(stamp)
+        turtle_id = str(turtle_id).replace("/", "")
+        if not turtle_id:
+            return
+
+        with self._lock:
+            if self._closed:
+                return
+            last = self._last_written_at.get(turtle_id)
+            if last is not None and stamp_seconds - last < self._period:
+                return
+
+            fp = self._files.get(turtle_id)
+            if fp is None:
+                path = self.path_for(turtle_id)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                fp = open(path, "a", encoding="utf-8")
+                self._files[turtle_id] = fp
+                self._paths[turtle_id] = path
+
+            line = json.dumps(pose_to_record(pose, stamp), separators=(",", ":")) + "\n"
+            fp.write(line)
+            fp.flush()
+            self._last_written_at[turtle_id] = stamp_seconds
+
+    def __call__(self, turtle_id: str, pose: Any, stamp: Any) -> None:
+        self.on_pose(turtle_id, pose, stamp)
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+            files = tuple(self._files.values())
+            self._files.clear()
+        for fp in files:
+            try:
+                fp.flush()
+            except OSError:
+                pass
+            try:
+                fp.close()
+            except OSError:
+                pass
+
+    def close_all(self) -> None:
+        self.close()
+
+
 class PoseLogger:
     """
-    Subscribe to /{turtle_id}/pose and append one JSON line per period to pose.jsonl.
+    Subscribe to /{turtle_id}/pose and append one JSON line per period.
+
+    This single-turtle wrapper is kept for compatibility. New multi-turtle code
+    should use :class:`PoseLogConsumer` with ``PoseHub``.
+
     Requires rospy.AsyncSpinner (or similar) so callbacks run while the main thread is busy.
     """
 
@@ -114,7 +217,7 @@ class PoseLogger:
         date_str = datetime.now().strftime("%Y-%m-%d")
         log_dir = build_log_dir(log_root, date_str, session_id, turtle_id)
         log_dir.mkdir(parents=True, exist_ok=True)
-        self._path = log_dir / "pose.jsonl"
+        self._path = log_dir / "location.jsonl"
         self._fp = open(self._path, "a", encoding="utf-8")
 
         self._turtle_id = turtle_id

--- a/src/turtle_agent/scripts/tools/turtle.py
+++ b/src/turtle_agent/scripts/tools/turtle.py
@@ -19,6 +19,11 @@ import rospy
 from geometry_msgs.msg import Twist
 from langchain.agents import tool
 from std_srvs.srv import Empty
+from turtle_lifecycle import (
+    configure_turtle_lifecycle_listener,
+    notify_turtle_killed,
+    notify_turtle_spawned,
+)
 from turtlesim.msg import Pose
 from turtlesim.srv import Spawn, TeleportAbsolute, TeleportRelative, Kill, SetPen
 
@@ -131,6 +136,7 @@ def spawn_turtle(name: str, x: float, y: float, theta: float) -> str:
 
         global cmd_vel_pubs
         cmd_vel_pubs[name] = rospy.Publisher(f"/{name}/cmd_vel", Twist, queue_size=10)
+        notify_turtle_spawned(name)
 
         return f"{name} spawned at x: {x}, y: {y}, theta: {theta}."
     except Exception as e:
@@ -161,6 +167,7 @@ def kill_turtle(names: List[str]):
             kill()
 
             cmd_vel_pubs.pop(name, None)
+            notify_turtle_killed(name)
 
             response += f"Successfully killed {name}.\n"
         except rospy.ServiceException as e:

--- a/src/turtle_agent/scripts/turtle_agent.py
+++ b/src/turtle_agent/scripts/turtle_agent.py
@@ -39,7 +39,8 @@ import tools.turtle as turtle_tools
 import tools.obstacle as obstacle_tools
 from help import get_help
 from obstacle_store import ObstacleStore
-from pose_logger import PoseLogger
+from pose_hub import PoseHub
+from pose_logger import POSE_LOG_INTERVAL_SEC, PoseLogConsumer
 from llm import get_llm
 from prompts import get_prompts
 from static_map_loader import StaticMapLoadError, load_file
@@ -432,11 +433,19 @@ if __name__ == "__main__":
     spin_thread = threading.Thread(target=_ros_spin, name="rospy_spin", daemon=True)
     spin_thread.start()
 
-    pose_logger = PoseLogger()
-    pose_logger.start()
+    pose_hub = PoseHub()
+    pose_log_consumer = PoseLogConsumer(
+        period=float(rospy.get_param("~pose_log_interval", POSE_LOG_INTERVAL_SEC))
+    )
+    pose_hub.register_consumer(pose_log_consumer.on_pose)
+    registered_turtles = pose_hub.start_from_ros_graph_once()
+    rospy.loginfo("PoseHub registered turtles: %s", ", ".join(registered_turtles))
+    turtle_tools.configure_turtle_lifecycle_listener(pose_hub)
     try:
         main()
     finally:
-        pose_logger.stop()
+        turtle_tools.configure_turtle_lifecycle_listener(None)
+        pose_hub.stop()
+        pose_log_consumer.close()
         rospy.signal_shutdown("turtle_agent exiting")
         spin_thread.join(timeout=5.0)

--- a/src/turtle_agent/scripts/turtle_lifecycle.py
+++ b/src/turtle_agent/scripts/turtle_lifecycle.py
@@ -1,0 +1,43 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import rospy
+
+_TURTLE_LIFECYCLE_LISTENER = None
+
+
+def configure_turtle_lifecycle_listener(listener):
+    """Inject a listener notified after successful turtle spawn/kill calls."""
+    global _TURTLE_LIFECYCLE_LISTENER
+    _TURTLE_LIFECYCLE_LISTENER = listener
+
+
+def notify_turtle_spawned(name: str) -> None:
+    listener = _TURTLE_LIFECYCLE_LISTENER
+    if listener is None:
+        return
+    try:
+        listener.on_turtle_spawned(name)
+    except Exception as e:
+        rospy.logwarn("turtle lifecycle listener spawn notification failed: %s", e)
+
+
+def notify_turtle_killed(name: str) -> None:
+    listener = _TURTLE_LIFECYCLE_LISTENER
+    if listener is None:
+        return
+    try:
+        listener.on_turtle_killed(name)
+    except Exception as e:
+        rospy.logwarn("turtle lifecycle listener kill notification failed: %s", e)

--- a/tests/test_turtle_agent/test_pose_hub.py
+++ b/tests/test_turtle_agent/test_pose_hub.py
@@ -1,0 +1,111 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "src" / "turtle_agent" / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+from pose_hub import PoseHub, extract_turtle_name_from_pose_topic  # noqa: E402
+
+
+class FakeSubscriber:
+    def __init__(self, topic, callback):
+        self.topic = topic
+        self.callback = callback
+        self.unregistered = False
+
+    def unregister(self):
+        self.unregistered = True
+
+
+class TestExtractTurtleName(unittest.TestCase):
+    def test_accepts_top_level_turtlesim_pose_topic(self):
+        self.assertEqual(
+            extract_turtle_name_from_pose_topic("/turtle1/pose", "turtlesim/Pose"),
+            "turtle1",
+        )
+
+    def test_rejects_non_pose_topics(self):
+        self.assertIsNone(
+            extract_turtle_name_from_pose_topic(
+                "/turtle1/cmd_vel", "geometry_msgs/Twist"
+            )
+        )
+        self.assertIsNone(
+            extract_turtle_name_from_pose_topic("/ns/turtle1/pose", "turtlesim/Pose")
+        )
+
+
+class TestPoseHub(unittest.TestCase):
+    def setUp(self):
+        self.subscribers = {}
+
+        def subscriber_factory(topic, callback):
+            sub = FakeSubscriber(topic, callback)
+            self.subscribers[topic] = sub
+            return sub
+
+        self.hub = PoseHub(
+            subscriber_factory=subscriber_factory,
+            time_source=lambda: {"secs": 1, "nsecs": 2},
+        )
+
+    def test_register_turtle_is_idempotent(self):
+        self.assertTrue(self.hub.register_turtle("turtle1"))
+        self.assertFalse(self.hub.register_turtle("turtle1"))
+        self.assertEqual(list(self.subscribers), ["/turtle1/pose"])
+
+    def test_start_from_ros_graph_once_filters_topics(self):
+        hub = PoseHub(
+            subscriber_factory=lambda topic, callback: FakeSubscriber(topic, callback),
+            topic_provider=lambda: [
+                ("/turtle1/pose", "turtlesim/Pose"),
+                ("/turtle2/pose", "turtlesim/msg/Pose"),
+                ("/turtle1/cmd_vel", "geometry_msgs/Twist"),
+                ("/ns/turtle3/pose", "turtlesim/Pose"),
+            ],
+            time_source=lambda: {"secs": 1, "nsecs": 0},
+        )
+        self.assertEqual(hub.start_from_ros_graph_once(), ("turtle1", "turtle2"))
+
+    def test_callback_updates_snapshot_and_consumers(self):
+        events = []
+        self.hub.register_consumer(
+            lambda name, pose, stamp: events.append((name, pose, stamp))
+        )
+        self.hub.register_turtle("turtle1")
+
+        pose = SimpleNamespace(x=1.0)
+        self.subscribers["/turtle1/pose"].callback(pose)
+
+        snapshot = self.hub.snapshot()
+        self.assertIs(snapshot["turtle1"][0], pose)
+        self.assertEqual(snapshot["turtle1"][1], {"secs": 1, "nsecs": 2})
+        self.assertEqual(events, [("turtle1", pose, {"secs": 1, "nsecs": 2})])
+
+    def test_unregister_cleans_up(self):
+        self.hub.register_turtle("turtle1")
+        sub = self.subscribers["/turtle1/pose"]
+        self.assertTrue(self.hub.unregister_turtle("turtle1"))
+        self.assertTrue(sub.unregistered)
+        self.assertEqual(self.hub.snapshot(), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_turtle_agent/test_pose_logger.py
+++ b/tests/test_turtle_agent/test_pose_logger.py
@@ -25,7 +25,9 @@ sys.path.insert(0, str(_SCRIPTS))
 
 from pose_logger import (  # noqa: E402
     POSE_LOG_INTERVAL_SEC,
+    PoseLogConsumer,
     build_log_dir,
+    build_location_log_path,
     pose_to_record,
     resolve_log_root,
 )
@@ -37,7 +39,15 @@ class TestBuildLogDir(unittest.TestCase):
         p = build_log_dir(root, "2026-04-23", "sess-1", "turtle1")
         self.assertEqual(
             p,
-            Path("/tmp/logs-root/2026-04-23/location/sess-1/turtle1"),
+            Path("/tmp/logs-root/2026-04-23/sess-1/turtle1"),
+        )
+
+    def test_location_log_path(self):
+        root = Path("/tmp/logs-root")
+        p = build_location_log_path(root, "2026-04-23", "sess-1", "turtle1")
+        self.assertEqual(
+            p,
+            Path("/tmp/logs-root/2026-04-23/sess-1/turtle1/location.jsonl"),
         )
 
 
@@ -90,6 +100,38 @@ class TestResolveLogRoot(unittest.TestCase):
 class TestPoseLogIntervalConstant(unittest.TestCase):
     def test_default_one_second(self):
         self.assertEqual(POSE_LOG_INTERVAL_SEC, 1.0)
+
+
+class TestPoseLogConsumer(unittest.TestCase):
+    def test_writes_one_file_per_turtle_with_sampling(self):
+        import json
+        import tempfile
+
+        pose = SimpleNamespace(
+            x=1.0,
+            y=2.0,
+            theta=0.5,
+            linear_velocity=0.1,
+            angular_velocity=0.2,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            consumer = PoseLogConsumer(
+                period=1.0,
+                log_root=Path(tmp),
+                date_str="2026-04-23",
+                session_id="sess-1",
+            )
+            try:
+                consumer.on_pose("turtle1", pose, {"secs": 10, "nsecs": 0})
+                consumer.on_pose("turtle1", pose, {"secs": 10, "nsecs": 500000000})
+                consumer.on_pose("turtle1", pose, {"secs": 11, "nsecs": 0})
+            finally:
+                consumer.close()
+
+            path = Path(tmp) / "2026-04-23" / "sess-1" / "turtle1" / "location.jsonl"
+            rows = [json.loads(line) for line in path.read_text().splitlines()]
+            self.assertEqual(len(rows), 2)
+            self.assertEqual(rows[0]["x"], 1.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_turtle_agent/test_turtle_lifecycle.py
+++ b/tests/test_turtle_agent/test_turtle_lifecycle.py
@@ -1,0 +1,172 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import importlib
+import sys
+import types
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "src" / "turtle_agent" / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+
+class FakeTool:
+    def __init__(self, func):
+        self.func = func
+
+    def invoke(self, args):
+        return self.func(**args)
+
+
+def fake_tool(func):
+    return FakeTool(func)
+
+
+class FakeRospy(types.ModuleType):
+    class ROSException(Exception):
+        pass
+
+    class ServiceException(Exception):
+        pass
+
+    def __init__(self):
+        super().__init__("rospy")
+        self.calls = []
+        self.warnings = []
+
+    def Publisher(self, topic, msg_type, queue_size=10):
+        return {"topic": topic, "msg_type": msg_type, "queue_size": queue_size}
+
+    def wait_for_service(self, name, timeout=5):
+        self.calls.append(("wait_for_service", name, timeout))
+
+    def ServiceProxy(self, name, service_type):
+        def proxy(*args, **kwargs):
+            self.calls.append(("service", name, args, kwargs))
+
+        return proxy
+
+    def logwarn(self, message, *args):
+        self.warnings.append(message % args if args else message)
+
+
+class FakeListener:
+    def __init__(self):
+        self.spawned = []
+        self.killed = []
+
+    def on_turtle_spawned(self, name):
+        self.spawned.append(name)
+
+    def on_turtle_killed(self, name):
+        self.killed.append(name)
+
+
+class TestTurtleLifecycleHooks(unittest.TestCase):
+    def setUp(self):
+        self.old_modules = {}
+        self.stub_names = [
+            "rospy",
+            "geometry_msgs",
+            "geometry_msgs.msg",
+            "langchain",
+            "langchain.agents",
+            "std_srvs",
+            "std_srvs.srv",
+            "turtlesim",
+            "turtlesim.msg",
+            "turtlesim.srv",
+            "turtle_lifecycle",
+            "tools.turtle",
+        ]
+        for name in self.stub_names:
+            self.old_modules[name] = sys.modules.get(name)
+            sys.modules.pop(name, None)
+
+        self.rospy = FakeRospy()
+        sys.modules["rospy"] = self.rospy
+
+        geometry_msgs = types.ModuleType("geometry_msgs")
+        geometry_msgs_msg = types.ModuleType("geometry_msgs.msg")
+        geometry_msgs_msg.Twist = object
+        geometry_msgs.msg = geometry_msgs_msg
+        sys.modules["geometry_msgs"] = geometry_msgs
+        sys.modules["geometry_msgs.msg"] = geometry_msgs_msg
+
+        langchain = types.ModuleType("langchain")
+        langchain_agents = types.ModuleType("langchain.agents")
+        langchain_agents.tool = fake_tool
+        langchain.agents = langchain_agents
+        sys.modules["langchain"] = langchain
+        sys.modules["langchain.agents"] = langchain_agents
+
+        std_srvs = types.ModuleType("std_srvs")
+        std_srvs_srv = types.ModuleType("std_srvs.srv")
+        std_srvs_srv.Empty = object
+        std_srvs.srv = std_srvs_srv
+        sys.modules["std_srvs"] = std_srvs
+        sys.modules["std_srvs.srv"] = std_srvs_srv
+
+        turtlesim = types.ModuleType("turtlesim")
+        turtlesim_msg = types.ModuleType("turtlesim.msg")
+        turtlesim_msg.Pose = object
+        turtlesim_srv = types.ModuleType("turtlesim.srv")
+        turtlesim_srv.Spawn = object
+        turtlesim_srv.TeleportAbsolute = object
+        turtlesim_srv.TeleportRelative = object
+        turtlesim_srv.Kill = object
+        turtlesim_srv.SetPen = object
+        turtlesim.msg = turtlesim_msg
+        turtlesim.srv = turtlesim_srv
+        sys.modules["turtlesim"] = turtlesim
+        sys.modules["turtlesim.msg"] = turtlesim_msg
+        sys.modules["turtlesim.srv"] = turtlesim_srv
+
+        self.turtle = importlib.import_module("tools.turtle")
+
+    def tearDown(self):
+        self.turtle.configure_turtle_lifecycle_listener(None)
+        sys.modules.pop("turtle_lifecycle", None)
+        sys.modules.pop("tools.turtle", None)
+        for name, module in self.old_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+    def test_spawn_success_notifies_listener(self):
+        listener = FakeListener()
+        self.turtle.configure_turtle_lifecycle_listener(listener)
+
+        output = self.turtle.spawn_turtle.invoke(
+            {"name": "turtle2", "x": 1.0, "y": 2.0, "theta": 0.0}
+        )
+
+        self.assertIn("turtle2 spawned", output)
+        self.assertEqual(listener.spawned, ["turtle2"])
+
+    def test_kill_success_notifies_listener(self):
+        listener = FakeListener()
+        self.turtle.configure_turtle_lifecycle_listener(listener)
+
+        output = self.turtle.kill_turtle.invoke({"names": ["turtle2"]})
+
+        self.assertIn("Successfully killed turtle2", output)
+        self.assertEqual(listener.killed, ["turtle2"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 내용

- PoseHub를 추가하여 turtlesim pose topic을 중앙에서 구독하고, 최신 pose snapshot과 consumer fan-out 구조를 제공합니다.
- 시작 시 ROS graph를 1회 스캔하여 기존 `/turtle/pose` topic을 등록하고, 이후 turtle spawn/kill tool의 lifecycle hook을 통해 동적으로 등록/해제합니다.
- PoseLogger를 PoseHub consumer 기반으로 정리하여 다중 거북이 위치 로그를 `logs/<date>/<session>/<turtle>/location.jsonl` 구조로 기록합니다.
- turtle spawn/kill 성공 이벤트 전달 로직을 `turtle_lifecycle.py`로 분리하여 `tools/turtle.py`의 변경 범위를 최소화했습니다.
- PoseHub, pose log consumer, turtle lifecycle hook 단위 테스트를 추가했습니다.

## 구현 범위

- PoseHub 추적 단위는 turtle name입니다.
- kill 시 해당 turtle의 subscriber와 latest pose를 제거합니다.
- 동일 이름으로 재스폰하면 같은 turtle name으로 다시 등록합니다.
- 같은 세션에서 동일 turtle name이 재사용되는 경우, 로그는 같은 `location.jsonl`에 이어서 기록됩니다. 생명주기 인스턴스별 로그 분리는 이번 범위의 한계로 둡니다.

## 테스트

- [x] `python3 -m unittest tests.test_turtle_agent.test_pose_hub tests.test_turtle_agent.test_pose_logger tests.test_turtle_agent.test_turtle_lifecycle -v`

## 참고

- 관련 이슈: #17
- 부모 이슈: #4

Made with [Cursor](https://cursor.com)