### PR TITLE
etc: AGENTS.md에서 ruff/lint 수동 검사 항목 제거

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,18 +103,6 @@
 
 ## 로컬 품질 검사
 
-커밋 전 아래 두 단계를 로컬에서 수행한다.
-
-### Ruff (lint + format)
-
-```bash
-uv run ruff check src/    # lint 오류 확인
-uv run ruff format src/   # 포맷 자동 수정
-```
-
-- `ruff check`에서 오류가 없는 상태로 커밋한다.
-- 설정은 `pyproject.toml`의 `[tool.ruff]` 섹션을 따른다.
-
 ### 디버깅 (VS Code)
 
 `.vscode/launch.json`에 두 가지 구성이 있다.


### PR DESCRIPTION
## 연관 이슈
- Closes #6

## 변경 내용
- `## 로컬 품질 검사` 섹션에서 `### Ruff (lint + format)` 서브섹션 제거
- ruff check/format은 pre-commit 하네스가 자동 처리하므로 에이전트용 수동 지침은 중복에 해당

## 테스트
- [x] 로컬 실행 테스트 완료
- [x] 회귀 영향 확인 (문서 변경만, 기능 영향 없음)