### PR TITLE
feat(turtle_agent): PoseHub·ObstacleStore 기반 충돌 감지 및 collision.jsonl (#19)

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -41,7 +41,9 @@ case "$(uname)" in
         # Keep XQuartz's DISPLAY or default to :0
         export DISPLAY=${DISPLAY:-:0}
         xhost +local:docker &>/dev/null || true
-        
+        # host.docker.internal X clients may appear as localhost on the host
+        xhost +localhost &>/dev/null || true
+
         # Check if XQuartz is running and properly configured
         if ! pgrep -xq "Xquartz" && ! pgrep -xq "X11"; then
             echo "Error: XQuartz is not running. Please start XQuartz and try again."
@@ -82,10 +84,13 @@ echo "Running the Docker container..."
 # Remote debug: export ROSA_DEBUGPY=1 before running; macOS publishes debugpy port to the host.
 DEBUGPY_PORT="${ROSA_DEBUGPY_PORT:-5678}"
 if [ "$(uname)" = "Darwin" ]; then
+    # macOS: LAN IP in DISPLAY often does not route from the Linux VM; use
+    # host.docker.internal. Override: ROSA_DOCKER_DISPLAY=host.example.com:0 ./demo.sh
+    DOCKER_DISPLAY="${ROSA_DOCKER_DISPLAY:-host.docker.internal:0}"
     # macOS: Use host.docker.internal for X11
     docker run -it --rm --init --name $CONTAINER_NAME \
         -p "${DEBUGPY_PORT}:${DEBUGPY_PORT}" \
-        -e DISPLAY=192.168.38.39:0 \
+        -e DISPLAY="$DOCKER_DISPLAY" \
         -e HEADLESS=$HEADLESS \
         -e DEVELOPMENT=$DEVELOPMENT \
         -e ROSA_DEBUGPY="${ROSA_DEBUGPY:-}" \

--- a/src/turtle_agent/scripts/collision_event_sink.py
+++ b/src/turtle_agent/scripts/collision_event_sink.py
@@ -1,0 +1,45 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""ROS wiring: append :class:`CollisionEvent` to JSONL and optionally log."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import rospy
+from collision_monitor import CollisionEvent, collision_event_to_record
+from pose_logger import CollisionJsonlWriter
+from ros_params import get_bool_param
+
+
+def make_collision_event_sink(
+    jsonl: CollisionJsonlWriter,
+) -> Callable[[CollisionEvent], None]:
+    """Append each emitted event to ``collision.jsonl`` (``stay`` optional via param).
+
+    Terminal logging is off unless ``~collision_log_to_console`` is true; JSONL is always
+    written for non-filtered events.
+    """
+    log_stay = get_bool_param("~collision_log_stay", False)
+    log_to_console = get_bool_param("~collision_log_to_console", False)
+
+    def _sink(event: CollisionEvent) -> None:
+        if event.event_type == "stay" and not log_stay:
+            return
+        jsonl.write_record(collision_event_to_record(event))
+        if log_to_console:
+            rospy.loginfo("collision event: %s", event)
+
+    return _sink

--- a/src/turtle_agent/scripts/collision_monitor.py
+++ b/src/turtle_agent/scripts/collision_monitor.py
@@ -1,0 +1,231 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""PoseHub consumer that turns obstacle overlaps into collision events.
+
+The monitor is deliberately ROS-independent: poses only need ``x`` and ``y``
+attributes, and obstacles come from :class:`obstacle_store.ObstacleStore`.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, replace
+from typing import Any, Callable, Dict, Literal, Optional, Tuple
+
+from collision_geometry import (
+    any_segment_intersects_disc,
+    circle_intersects_aabb,
+    circles_overlap,
+)
+from obstacle_store import (
+    AabbGeometry,
+    CircleGeometry,
+    Obstacle,
+    ObstacleStore,
+    SegmentsGeometry,
+)
+
+CollisionEventType = Literal["enter", "stay", "exit"]
+CollisionType = Literal["turtle_obstacle", "turtle_turtle"]
+CollisionKey = Tuple[str, str, str]
+EventSink = Callable[["CollisionEvent"], None]
+
+
+@dataclass(frozen=True)
+class CollisionEvent:
+    event_type: CollisionEventType
+    collision_type: CollisionType
+    turtles: Tuple[str, ...]
+    stamp: Any
+    pose: Any
+    obstacle_id: Optional[str] = None
+    details: Optional[Dict[str, Any]] = None
+
+
+class CollisionMonitor:
+    """Detect turtle-obstacle and turtle-turtle collisions from pose updates."""
+
+    def __init__(
+        self,
+        obstacle_store: ObstacleStore,
+        *,
+        turtle_radius: float = 0.5,
+        emit_stay: bool = True,
+        event_sink: Optional[EventSink] = None,
+    ) -> None:
+        if turtle_radius < 0.0:
+            raise ValueError("turtle_radius must be non-negative")
+        self._store = obstacle_store
+        self._turtle_radius = float(turtle_radius)
+        self._emit_stay = emit_stay
+        self._event_sink = event_sink
+        self._lock = threading.RLock()
+        self._latest_poses: Dict[str, Tuple[Any, Any]] = {}
+        self._active: Dict[CollisionKey, CollisionEvent] = {}
+        self._events: list[CollisionEvent] = []
+
+    @property
+    def events(self) -> Tuple[CollisionEvent, ...]:
+        with self._lock:
+            return tuple(self._events)
+
+    def clear_events(self) -> None:
+        with self._lock:
+            self._events.clear()
+
+    def on_pose(self, turtle_name: str, pose: Any, stamp: Any) -> None:
+        """PoseHub consumer callback receiving ``(turtle_name, pose, stamp)``."""
+        with self._lock:
+            self._latest_poses[str(turtle_name)] = (pose, stamp)
+            current = self._collect_hits(stamp)
+            events = self._transition_events(current, stamp)
+            self._active = current
+            self._events.extend(events)
+
+        for event in events:
+            if self._event_sink is not None:
+                self._event_sink(event)
+
+    def _collect_hits(self, stamp: Any) -> Dict[CollisionKey, CollisionEvent]:
+        current: Dict[CollisionKey, CollisionEvent] = {}
+        obstacles = self._store.snapshot()
+        poses = dict(self._latest_poses)
+
+        for turtle_name in sorted(poses):
+            pose, _ = poses[turtle_name]
+            tx, ty = _pose_xy(pose)
+            for obstacle in obstacles:
+                if obstacle.kind == "turtle":
+                    continue
+                if _turtle_hits_obstacle(tx, ty, self._turtle_radius, obstacle):
+                    key = ("turtle_obstacle", turtle_name, obstacle.id)
+                    current[key] = CollisionEvent(
+                        event_type="enter",
+                        collision_type="turtle_obstacle",
+                        turtles=(turtle_name,),
+                        obstacle_id=obstacle.id,
+                        stamp=stamp,
+                        pose=pose,
+                        details={
+                            "obstacle_kind": obstacle.kind,
+                            "geometry": type(obstacle.geometry).__name__,
+                        },
+                    )
+
+        names = sorted(poses)
+        for i, turtle_a in enumerate(names):
+            pose_a, _ = poses[turtle_a]
+            ax, ay = _pose_xy(pose_a)
+            for turtle_b in names[i + 1 :]:
+                pose_b, _ = poses[turtle_b]
+                bx, by = _pose_xy(pose_b)
+                if circles_overlap(
+                    ax,
+                    ay,
+                    self._turtle_radius,
+                    bx,
+                    by,
+                    self._turtle_radius,
+                ):
+                    key = ("turtle_turtle", turtle_a, turtle_b)
+                    current[key] = CollisionEvent(
+                        event_type="enter",
+                        collision_type="turtle_turtle",
+                        turtles=(turtle_a, turtle_b),
+                        obstacle_id=None,
+                        stamp=stamp,
+                        pose=pose_a,
+                        details={"turtle_radius": self._turtle_radius},
+                    )
+        return current
+
+    def _transition_events(
+        self, current: Dict[CollisionKey, CollisionEvent], stamp: Any
+    ) -> Tuple[CollisionEvent, ...]:
+        events = []
+
+        for key in sorted(current):
+            hit = current[key]
+            if key not in self._active:
+                events.append(hit)
+            elif self._emit_stay:
+                events.append(replace(hit, event_type="stay"))
+
+        for key in sorted(set(self._active) - set(current)):
+            previous = self._active[key]
+            exit_pose = self._pose_for_event(previous)
+            events.append(
+                replace(previous, event_type="exit", stamp=stamp, pose=exit_pose)
+            )
+
+        return tuple(events)
+
+    def _pose_for_event(self, event: CollisionEvent) -> Any:
+        for turtle_name in event.turtles:
+            latest = self._latest_poses.get(turtle_name)
+            if latest is not None:
+                return latest[0]
+        return event.pose
+
+
+def collision_event_to_record(event: CollisionEvent) -> Dict[str, Any]:
+    """Build one JSON-serializable line for session ``collision.jsonl``."""
+    from pose_logger import pose_to_record
+
+    out: Dict[str, Any] = {
+        "event_type": event.event_type,
+        "collision_type": event.collision_type,
+        "turtles": list(event.turtles),
+    }
+    if event.obstacle_id is not None:
+        out["obstacle_id"] = event.obstacle_id
+    if event.details is not None:
+        out["details"] = event.details
+    out.update(pose_to_record(event.pose, event.stamp))
+    return out
+
+
+def _pose_xy(pose: Any) -> Tuple[float, float]:
+    return float(getattr(pose, "x")), float(getattr(pose, "y"))
+
+
+def _turtle_hits_obstacle(
+    turtle_x: float, turtle_y: float, turtle_radius: float, obstacle: Obstacle
+) -> bool:
+    geometry = obstacle.geometry
+    if isinstance(geometry, CircleGeometry):
+        return circles_overlap(
+            turtle_x,
+            turtle_y,
+            turtle_radius,
+            geometry.cx,
+            geometry.cy,
+            geometry.r,
+        )
+    if isinstance(geometry, AabbGeometry):
+        return circle_intersects_aabb(
+            turtle_x,
+            turtle_y,
+            turtle_radius,
+            geometry.min_x,
+            geometry.min_y,
+            geometry.max_x,
+            geometry.max_y,
+        )
+    if isinstance(geometry, SegmentsGeometry):
+        return any_segment_intersects_disc(
+            geometry.segments, turtle_x, turtle_y, turtle_radius
+        )
+    raise TypeError(f"unsupported obstacle geometry: {type(geometry).__name__}")

--- a/src/turtle_agent/scripts/pose_logger.py
+++ b/src/turtle_agent/scripts/pose_logger.py
@@ -54,6 +54,50 @@ def build_location_log_path(
     return build_log_dir(log_root, date_str, session_id, turtle_id) / "location.jsonl"
 
 
+def build_collision_log_path(
+    log_root: Path, date_str: str, session_id: str
+) -> Path:
+    """Return ``logs/<date>/<session>/collision.jsonl`` (per-session, all turtles)."""
+    return (log_root / date_str / session_id / "collision.jsonl").resolve()
+
+
+class CollisionJsonlWriter:
+    """Append one JSON object per line to a session ``collision.jsonl`` file."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._lock = threading.Lock()
+        self._fp: Optional[TextIO] = None
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def write_record(self, record: Dict[str, Any]) -> None:
+        with self._lock:
+            if self._fp is None:
+                self._path.parent.mkdir(parents=True, exist_ok=True)
+                self._fp = self._path.open("a", encoding="utf-8")
+            self._fp.write(
+                json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n"
+            )
+            self._fp.flush()
+
+    def close(self) -> None:
+        with self._lock:
+            fp = self._fp
+            self._fp = None
+        if fp is not None:
+            try:
+                fp.flush()
+            except OSError:
+                pass
+            try:
+                fp.close()
+            except OSError:
+                pass
+
+
 def pose_to_record(pose: Any, stamp: Any) -> Dict[str, Any]:
     """
     Build one JSON-serializable dict from a turtlesim Pose-like object and a time stamp.
@@ -112,6 +156,10 @@ class PoseLogConsumer:
         return build_location_log_path(
             self._log_root, self._date_str, self._session_id, turtle_id
         )
+
+    def collision_log_path(self) -> Path:
+        """Path for this session's ``collision.jsonl`` (sibling to per-turtle dirs)."""
+        return build_collision_log_path(self._log_root, self._date_str, self._session_id)
 
     def on_pose(self, turtle_id: str, pose: Any, stamp: Any) -> None:
         stamp_seconds = _stamp_to_seconds(stamp)

--- a/src/turtle_agent/scripts/ros_params.py
+++ b/src/turtle_agent/scripts/ros_params.py
@@ -1,0 +1,33 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Small helpers for reading ROS parameters with explicit type coercion."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def coerce_bool_param_value(value: Any) -> bool:
+    """Interpret common string false values before falling back to ``bool``."""
+    if isinstance(value, str):
+        return value.strip().lower() not in ("0", "false", "no", "off", "")
+    return bool(value)
+
+
+def get_bool_param(name: str, default: bool) -> bool:
+    """Read a ROS parameter and coerce it to bool in a string-safe way."""
+    import rospy
+
+    return coerce_bool_param_value(rospy.get_param(name, default))

--- a/src/turtle_agent/scripts/static_world.py
+++ b/src/turtle_agent/scripts/static_world.py
@@ -1,0 +1,42 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Load and optionally draw static obstacles into a shared ObstacleStore."""
+
+from __future__ import annotations
+
+from obstacle_store import ObstacleStore
+from static_map_loader import StaticMapLoadError, load_file
+from world_builder import draw_static_world
+
+
+def load_static_world(obstacle_store: ObstacleStore) -> None:
+    """Load configured static obstacles and optionally draw them in turtlesim."""
+    import rospy
+
+    path = str(rospy.get_param("~static_obstacles_file", "")).strip()
+    if path:
+        try:
+            load_file(obstacle_store, path)
+        except StaticMapLoadError as e:
+            rospy.logerr("static obstacles: %s", e)
+            raise
+        if rospy.get_param("~draw_static_world", True):
+            try:
+                count = draw_static_world(obstacle_store)
+                rospy.loginfo("static world builder drew %s segments", count)
+            except Exception as e:
+                rospy.logerr("static world builder failed: %s", e)
+                if rospy.get_param("~world_builder_required", True):
+                    raise

--- a/src/turtle_agent/scripts/turtle_agent.py
+++ b/src/turtle_agent/scripts/turtle_agent.py
@@ -24,27 +24,32 @@ from typing import Optional
 import dotenv
 import pyinputplus as pyip
 import rospy
-from langchain.agents import tool, Tool
+import tools.obstacle as obstacle_tools
+import tools.turtle as turtle_tools
+from collision_event_sink import make_collision_event_sink
+from collision_monitor import CollisionMonitor
+from help import get_help
+from langchain.agents import Tool, tool
 
 # from langchain_ollama import ChatOllama
-from rich.console import Console
-from rich.console import Group
+from llm import get_llm
+from obstacle_store import ObstacleStore
+from pose_hub import PoseHub
+from pose_logger import (
+    POSE_LOG_INTERVAL_SEC,
+    CollisionJsonlWriter,
+    PoseLogConsumer,
+)
+from prompts import get_prompts
+from rich.console import Console, Group
 from rich.live import Live
 from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.text import Text
-from rosa import ROSA
+from ros_params import get_bool_param
+from static_world import load_static_world
 
-import tools.turtle as turtle_tools
-import tools.obstacle as obstacle_tools
-from help import get_help
-from obstacle_store import ObstacleStore
-from pose_hub import PoseHub
-from pose_logger import POSE_LOG_INTERVAL_SEC, PoseLogConsumer
-from llm import get_llm
-from prompts import get_prompts
-from static_map_loader import StaticMapLoadError, load_file
-from world_builder import draw_static_world
+from rosa import ROSA
 
 
 def _maybe_attach_debugpy() -> None:
@@ -388,26 +393,18 @@ class TurtleAgent(ROSA):
         console.print("[bold]End of events[/bold]\n")
 
 
-def main():
+def main(
+    obstacle_store: Optional[ObstacleStore] = None,
+    *,
+    load_static_world_once: bool = True,
+) -> None:
     dotenv.load_dotenv(dotenv.find_dotenv())
 
     streaming = rospy.get_param("~streaming", False)
-    obstacle_store = ObstacleStore()
-    path = str(rospy.get_param("~static_obstacles_file", "")).strip()
-    if path:
-        try:
-            load_file(obstacle_store, path)
-        except StaticMapLoadError as e:
-            rospy.logerr("static obstacles: %s", e)
-            raise
-        if rospy.get_param("~draw_static_world", True):
-            try:
-                count = draw_static_world(obstacle_store)
-                rospy.loginfo("static world builder drew %s segments", count)
-            except Exception as e:
-                rospy.logerr("static world builder failed: %s", e)
-                if rospy.get_param("~world_builder_required", True):
-                    raise
+    if obstacle_store is None:
+        obstacle_store = ObstacleStore()
+    if load_static_world_once:
+        load_static_world(obstacle_store)
 
     turtle_agent = TurtleAgent(
         verbose=False, streaming=streaming, obstacle_store=obstacle_store
@@ -433,19 +430,32 @@ if __name__ == "__main__":
     spin_thread = threading.Thread(target=_ros_spin, name="rospy_spin", daemon=True)
     spin_thread.start()
 
+    obstacle_store = ObstacleStore()
+    load_static_world(obstacle_store)
     pose_hub = PoseHub()
     pose_log_consumer = PoseLogConsumer(
         period=float(rospy.get_param("~pose_log_interval", POSE_LOG_INTERVAL_SEC))
     )
+    collision_jsonl = CollisionJsonlWriter(pose_log_consumer.collision_log_path())
+    if get_bool_param("~collision_log_to_console", False):
+        rospy.loginfo("collision log: %s", collision_jsonl.path)
+    collision_monitor = CollisionMonitor(
+        obstacle_store,
+        turtle_radius=float(rospy.get_param("~turtle_collision_radius", 0.5)),
+        emit_stay=get_bool_param("~collision_emit_stay", False),
+        event_sink=make_collision_event_sink(collision_jsonl),
+    )
     pose_hub.register_consumer(pose_log_consumer.on_pose)
+    pose_hub.register_consumer(collision_monitor.on_pose)
     registered_turtles = pose_hub.start_from_ros_graph_once()
     rospy.loginfo("PoseHub registered turtles: %s", ", ".join(registered_turtles))
     turtle_tools.configure_turtle_lifecycle_listener(pose_hub)
     try:
-        main()
+        main(obstacle_store=obstacle_store, load_static_world_once=False)
     finally:
         turtle_tools.configure_turtle_lifecycle_listener(None)
         pose_hub.stop()
         pose_log_consumer.close()
+        collision_jsonl.close()
         rospy.signal_shutdown("turtle_agent exiting")
         spin_thread.join(timeout=5.0)

--- a/tests/test_turtle_agent/test_collision_monitor.py
+++ b/tests/test_turtle_agent/test_collision_monitor.py
@@ -1,0 +1,177 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import sys
+import time
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "src" / "turtle_agent" / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+from collision_monitor import (  # noqa: E402
+    CollisionEvent,
+    CollisionMonitor,
+    collision_event_to_record,
+)
+from obstacle_store import (  # noqa: E402
+    AabbGeometry,
+    CircleGeometry,
+    Obstacle,
+    ObstacleStore,
+    SegmentsGeometry,
+)
+
+
+def pose(x: float, y: float):
+    return SimpleNamespace(x=x, y=y, theta=0.0)
+
+
+class TestCollisionEventToRecord(unittest.TestCase):
+    def test_includes_event_fields_and_pose(self) -> None:
+        p = SimpleNamespace(
+            x=1.0,
+            y=2.0,
+            theta=0.5,
+            linear_velocity=0.0,
+            angular_velocity=0.0,
+        )
+        ev = CollisionEvent(
+            event_type="enter",
+            collision_type="turtle_obstacle",
+            turtles=("turtle1",),
+            stamp=SimpleNamespace(secs=3, nsecs=4),
+            pose=p,
+            obstacle_id="wet",
+            details={"geometry": "AabbGeometry"},
+        )
+        rec = collision_event_to_record(ev)
+        self.assertEqual(rec["event_type"], "enter")
+        self.assertEqual(rec["collision_type"], "turtle_obstacle")
+        self.assertEqual(rec["turtles"], ["turtle1"])
+        self.assertEqual(rec["obstacle_id"], "wet")
+        self.assertEqual(
+            rec["t_ros"],
+            {"secs": 3, "nsecs": 4},
+        )
+        self.assertEqual(rec["x"], 1.0)
+        self.assertEqual(rec["y"], 2.0)
+
+
+class TestCollisionMonitor(unittest.TestCase):
+    def test_circle_obstacle_enter_stay_exit(self):
+        store = ObstacleStore()
+        store.upsert(Obstacle("circle", "static", CircleGeometry(0.0, 0.0, 1.0), None))
+        monitor = CollisionMonitor(store, turtle_radius=0.5)
+
+        monitor.on_pose("turtle1", pose(1.0, 0.0), "t0")
+        self.assertEqual(monitor.events[-1].event_type, "enter")
+        self.assertEqual(monitor.events[-1].collision_type, "turtle_obstacle")
+        self.assertEqual(monitor.events[-1].obstacle_id, "circle")
+
+        monitor.clear_events()
+        monitor.on_pose("turtle1", pose(1.0, 0.0), "t1")
+        self.assertEqual([e.event_type for e in monitor.events], ["stay"])
+
+        monitor.clear_events()
+        monitor.on_pose("turtle1", pose(5.0, 0.0), "t2")
+        self.assertEqual([e.event_type for e in monitor.events], ["exit"])
+
+    def test_aabb_obstacle_collision(self):
+        store = ObstacleStore()
+        store.upsert(Obstacle("box", "static", AabbGeometry(2.0, 2.0, 4.0, 4.0), None))
+        monitor = CollisionMonitor(store, turtle_radius=0.5)
+
+        monitor.on_pose("turtle1", pose(1.6, 3.0), "t0")
+
+        self.assertEqual(len(monitor.events), 1)
+        self.assertEqual(monitor.events[0].obstacle_id, "box")
+        self.assertEqual(monitor.events[0].event_type, "enter")
+
+    def test_segments_obstacle_collision(self):
+        store = ObstacleStore()
+        store.upsert(
+            Obstacle(
+                "wall",
+                "static",
+                SegmentsGeometry((((0.0, 0.0), (2.0, 0.0)),)),
+                None,
+            )
+        )
+        monitor = CollisionMonitor(store, turtle_radius=0.25)
+
+        monitor.on_pose("turtle1", pose(1.0, 0.2), "t0")
+
+        self.assertEqual(len(monitor.events), 1)
+        self.assertEqual(monitor.events[0].obstacle_id, "wall")
+
+    def test_turtle_turtle_enter_and_exit(self):
+        store = ObstacleStore()
+        monitor = CollisionMonitor(store, turtle_radius=0.5)
+
+        monitor.on_pose("turtle1", pose(0.0, 0.0), "t0")
+        self.assertEqual(monitor.events, ())
+        monitor.on_pose("turtle2", pose(0.75, 0.0), "t1")
+        self.assertEqual(monitor.events[-1].event_type, "enter")
+        self.assertEqual(monitor.events[-1].collision_type, "turtle_turtle")
+        self.assertEqual(monitor.events[-1].turtles, ("turtle1", "turtle2"))
+
+        monitor.clear_events()
+        monitor.on_pose("turtle2", pose(2.0, 0.0), "t2")
+        self.assertEqual([e.event_type for e in monitor.events], ["exit"])
+
+    def test_emit_stay_false_suppresses_repeat_events(self):
+        store = ObstacleStore()
+        store.upsert(Obstacle("c", "static", CircleGeometry(0.0, 0.0, 1.0), None))
+        monitor = CollisionMonitor(store, turtle_radius=0.5, emit_stay=False)
+
+        monitor.on_pose("turtle1", pose(0.0, 0.0), "t0")
+        monitor.clear_events()
+        monitor.on_pose("turtle1", pose(0.0, 0.0), "t1")
+
+        self.assertEqual(monitor.events, ())
+
+    def test_expired_obstacle_snapshot_generates_exit(self):
+        store = ObstacleStore()
+        store.upsert(
+            Obstacle(
+                "temp",
+                "ephemeral",
+                CircleGeometry(0.0, 0.0, 1.0),
+                time.monotonic() + 0.05,
+            )
+        )
+        monitor = CollisionMonitor(store, turtle_radius=0.5)
+        monitor.on_pose("turtle1", pose(0.0, 0.0), "t0")
+        monitor.clear_events()
+
+        time.sleep(0.1)
+        monitor.on_pose("turtle1", pose(0.0, 0.0), "t1")
+
+        self.assertEqual([e.event_type for e in monitor.events], ["exit"])
+
+    def test_turtle_kind_obstacle_is_skipped_for_obstacle_layer(self):
+        store = ObstacleStore()
+        store.upsert(Obstacle("t2", "turtle", CircleGeometry(0.0, 0.0, 10.0), None))
+        monitor = CollisionMonitor(store, turtle_radius=0.5)
+
+        monitor.on_pose("turtle1", pose(0.0, 0.0), "t0")
+
+        self.assertEqual(monitor.events, ())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_turtle_agent/test_pose_logger.py
+++ b/tests/test_turtle_agent/test_pose_logger.py
@@ -25,9 +25,11 @@ sys.path.insert(0, str(_SCRIPTS))
 
 from pose_logger import (  # noqa: E402
     POSE_LOG_INTERVAL_SEC,
+    CollisionJsonlWriter,
     PoseLogConsumer,
-    build_log_dir,
+    build_collision_log_path,
     build_location_log_path,
+    build_log_dir,
     pose_to_record,
     resolve_log_root,
 )
@@ -49,6 +51,35 @@ class TestBuildLogDir(unittest.TestCase):
             p,
             Path("/tmp/logs-root/2026-04-23/sess-1/turtle1/location.jsonl"),
         )
+
+    def test_collision_log_path(self):
+        root = Path("/tmp/logs-root")
+        p = build_collision_log_path(root, "2026-04-23", "sess-1")
+        self.assertEqual(
+            p,
+            (root / "2026-04-23" / "sess-1" / "collision.jsonl").resolve(),
+        )
+
+    def test_pose_log_consumer_collision_log_path(self):
+        c = PoseLogConsumer(
+            log_root=Path("/tmp/lr"), session_id="sid", date_str="2026-01-01"
+        )
+        self.assertEqual(
+            c.collision_log_path(),
+            Path("/tmp/lr/2026-01-01/sid/collision.jsonl").resolve(),
+        )
+
+
+class TestCollisionJsonlWriter(unittest.TestCase):
+    def test_write_and_close(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "collision.jsonl"
+            w = CollisionJsonlWriter(p)
+            w.write_record({"a": 1})
+            w.close()
+            self.assertEqual(p.read_text().strip(), '{"a":1}')
 
 
 class TestPoseToRecord(unittest.TestCase):


### PR DESCRIPTION
### 관련 이슈

- Closes #19
- 상위: #4 (단계 6)

### 개요

`PoseHub`의 다중 거북이 pose와 `ObstacleStore` 스냅샷을 사용해, turtlesim에 대응하는 **기하(원·AABB·선분) 기반** 충돌 상태를 감지하고, 상태 변화에 따라 `enter` / `stay` / `exit` 이벤트를 기록한다. #17·PR #18의 `PoseHub`·`ObstacleStore`·`collision_geometry` 전제를 따른다.

### 구현 요약

- **`CollisionMonitor`** (`on_pose` consumer): 터틀을 반경 `~turtle_collision_radius` 원으로 보고, 장앙물(원 / AABB / 선분) 및 거북이–거북이에 대해 겹침을 판정한 뒤, 이전 프레임 대비 `enter`·`stay`·`exit`를 생성한다. `turtle` 종류(다른 터틀 실루엣)는 장앙물 레이어에서 제외한다.
- **출력**: 세션 경로 `logs/<날짜>/<session_id>/collision.jsonl`에 JSONL로 append. 이벤트는 `collision_event_to_record`로 `pose_to_record`와 동일 키(`t_ros`, `x`, `y`, `theta`, 속도 등)를 포함해 한 줄 JSON으로 직렬화한다.
- **연동**: `turtle_agent`에서 공유 `ObstacleStore`, 정적 맵 `load_static_world`와 함께 `PoseLogConsumer`·`CollisionMonitor`를 `PoseHub`에 등록한다.
- **ROS 파라미터**: `~collision_emit_stay`, `~collision_log_stay`, `~collision_log_to_console` 등으로 `stay` 기록·터미널 로그를 제어한다(기본은 콘솔에 충돌 이벤트를 반복 출력하지 않음).
- **모듈**: `collision_event_sink`에서 JSONL sink·옵션 로그를 분리.

### 비범위 (이 PR에서 다루지 않음, #19·#4에 명시된 대로)

- 물리 엔진, swept/연속 궤적 충돌, ROS2, 충돌 전용 ROS topic 발행.

### 테스트

- `python -m unittest tests.test_turtle_agent.test_collision_monitor tests.test_turtle_agent.test_pose_logger` 로컬에서 통과.

### 기타

- #19에 기재된 산출물·수락 기준을 충족하는 범위로만 변경한다.
