### PR TITLE
feat(turtle-agent): 시스템 프롬프트에 한국어 입력 정규화 추가

### DIFF
--- a/src/turtle_agent/scripts/prompts.py
+++ b/src/turtle_agent/scripts/prompts.py
@@ -24,6 +24,12 @@ def get_prompts():
         critical_instructions="SEQUENTIAL EXECUTION:\n"
         "Execute all drawing commands one at a time. Wait for each command to complete before issuing the next.\n"
         "\n"
+        "KOREAN INPUT NORMALIZATION:\n"
+        "When user input is in Korean, first normalize it internally into clear English intent before planning tool calls.\n"
+        "Use translation only for internal reasoning and do not reveal intermediate translated text.\n"
+        "Preserve numbers, units, coordinates, angles, colors, and turtle names when mapping arguments.\n"
+        "If Korean instructions are ambiguous, ask a brief clarification question in Korean instead of guessing.\n"
+        "\n"
         "MULTI-PART DRAWING WORKFLOW:\n"
         "1. Calculate all coordinates using calculate_rectangle_bounds for each component\n"
         "2. Verify spacing using check_rectangles_overlap - only check components that should NOT touch (e.g., door vs windows, not door vs base wall)\n"
@@ -41,6 +47,7 @@ def get_prompts():
         "Use size=1 for shapes unless specified otherwise.",
         constraints_and_guardrails="COMMAND ORDER:\n"
         "Execute teleport commands (teleport_absolute, teleport_relative) before movement commands (cmd_vel, twist publishing). All commands execute sequentially.\n"
+        "Apply the same safety and execution rules even when Korean input is normalized internally.\n"
         "\n"
         "BOUNDARIES:\n"
         "The turtle operates in an 11x11 space. Validate coordinates before executing movements.\n"
@@ -86,6 +93,7 @@ def get_prompts():
         "The new pose will always be returned after a twist or teleport command.",
         mission_and_objectives="Your mission is to draw perfect shapes and have fun with the turtle bots. "
         "You are also responsible for making turtle puns.\n"
+        "Provide final user-facing responses in Korean.\n"
         "\n"
         "EXAMPLE: Drawing a 3x3 house with door and 2 windows (using high-level tools):\n"
         "1. Plan layout with calculate_rectangle_bounds:\n"


### PR DESCRIPTION
﻿## 요약
- 관련 이슈: #23
- 별도 한국어 전용 에이전트 추가 대신, 기존 TurtleAgent의 시스템 프롬프트에 한국어 입력 정규화 규칙을 추가해 문제를 해결합니다.
- 한국어 사용자 명령은 내부적으로 영어 의도로 정규화해 도구 계획에 사용하고, 숫자/단위/좌표/이름 매핑은 보존하도록 명시했습니다.
- 사용자에게 보이는 최종 응답은 한국어로 유지하며, 기존 안전 규칙/순차 실행 규칙은 동일하게 적용합니다.

## 테스트 계획
- [ ] Docker에서 catkin build && source devel/setup.bash && roslaunch turtle_agent agent.launch streaming:=true 실행
- [ ] 한국어 명령("별 그려줘", "빨간색으로 바꿔줘", "왼쪽 위로 이동") 입력 시 도구 실행이 정상인지 확인
- [ ] 모호한 한국어 입력에서 짧은 한국어 확인 질문이 나오는지 확인
- [ ] 영어 명령 회귀 동작이 기존과 동일한지 확인
