### PR TITLE
feat: turtlesim 컨트롤 에이전트 런타임 추가

### DIFF
--- a/src/turtle_agent/launch/agent.launch
+++ b/src/turtle_agent/launch/agent.launch
@@ -3,6 +3,12 @@
     <arg name="static_obstacles_file" default="$(find turtle_agent)/config/static_obstacles_turtlesim.yaml" />
     <arg name="draw_static_world" default="true" />
     <arg name="world_builder_required" default="true" />
+    <arg name="agent_mode" default="single" />
+    <arg name="control_worker_count" default="2" />
+    <arg name="control_reset_turtlesim" default="false" />
+    <arg name="control_task_count" default="0" />
+    <arg name="control_task_timeout" default="0" />
+    <arg name="control_turtle_names" default="" />
 
     <node name="rosa_turtle_agent"
           pkg="turtle_agent"
@@ -15,5 +21,11 @@
         <param name="static_obstacles_file" value="$(arg static_obstacles_file)" />
         <param name="draw_static_world" value="$(arg draw_static_world)" />
         <param name="world_builder_required" value="$(arg world_builder_required)" />
+        <param name="agent_mode" value="$(arg agent_mode)" />
+        <param name="control_worker_count" value="$(arg control_worker_count)" />
+        <param name="control_reset_turtlesim" value="$(arg control_reset_turtlesim)" />
+        <param name="control_task_count" value="$(arg control_task_count)" />
+        <param name="control_task_timeout" value="$(arg control_task_timeout)" />
+        <param name="control_turtle_names" value="$(arg control_turtle_names)" />
     </node>
 </launch>

--- a/src/turtle_agent/scripts/turtle_agent.py
+++ b/src/turtle_agent/scripts/turtle_agent.py
@@ -48,6 +48,7 @@ from rich.panel import Panel
 from rich.text import Text
 from ros_params import get_bool_param
 from static_world import load_static_world
+from turtle_control_runtime import run_turtle_control_agent
 
 from rosa import ROSA
 
@@ -451,7 +452,14 @@ if __name__ == "__main__":
     rospy.loginfo("PoseHub registered turtles: %s", ", ".join(registered_turtles))
     turtle_tools.configure_turtle_lifecycle_listener(pose_hub)
     try:
-        main(obstacle_store=obstacle_store, load_static_world_once=False)
+        agent_mode = rospy.get_param("~agent_mode", "single").strip().lower()
+        if agent_mode == "control":
+            run_turtle_control_agent(
+                obstacle_store=obstacle_store,
+                lifecycle_listener=pose_hub,
+            )
+        else:
+            main(obstacle_store=obstacle_store, load_static_world_once=False)
     finally:
         turtle_tools.configure_turtle_lifecycle_listener(None)
         pose_hub.stop()

--- a/src/turtle_agent/scripts/turtle_control_agent.py
+++ b/src/turtle_agent/scripts/turtle_control_agent.py
@@ -1,0 +1,473 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""ROS-free orchestration for running one worker agent per turtle in parallel."""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+from concurrent.futures import (
+    FIRST_COMPLETED,
+    Future,
+    ThreadPoolExecutor,
+    TimeoutError,
+    as_completed,
+    wait,
+)
+from dataclasses import dataclass, field
+from time import monotonic
+from typing import Any, Callable, Deque, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from turtle_control_prompts import CONTROL_AGENT_PROMPT, WORKER_SYSTEM_PROMPT
+
+_ANSI_RESET = "\033[0m"
+_AGENT_COLORS = (
+    "\033[36m",  # cyan
+    "\033[35m",  # magenta
+    "\033[33m",  # yellow
+    "\033[32m",  # green
+    "\033[34m",  # blue
+    "\033[31m",  # red
+)
+
+DEFAULT_CONTROL_AGENT_PROMPT = CONTROL_AGENT_PROMPT
+DEFAULT_WORKER_SYSTEM_PROMPT = WORKER_SYSTEM_PROMPT
+
+
+@dataclass(frozen=True)
+class TurtleTask:
+    """A unit of work addressed to one turtle-specific worker agent."""
+
+    turtle_id: str
+    instruction: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TurtleTaskResult:
+    """Result for one turtle task, including isolated failures."""
+
+    turtle_id: str
+    ok: bool
+    instruction: str = ""
+    output: str = ""
+    error: str = ""
+    elapsed_seconds: float = 0.0
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+TurtleWorker = Callable[[TurtleTask], str]
+LogSink = Callable[[str], None]
+PromptPlanner = Callable[[str], Sequence[str]]
+
+
+class TurtleControlAgent:
+    """
+    Coordinate turtle-specific worker agents without importing ROS or turtlesim.
+
+    The control agent owns only orchestration: each worker is responsible for a
+    single turtle, while this class runs independent turtle tasks concurrently
+    and collects per-turtle results.
+    """
+
+    def __init__(
+        self,
+        workers: Mapping[str, TurtleWorker],
+        *,
+        max_workers: Optional[int] = None,
+        log_enabled: bool = False,
+        log_sink: Optional[LogSink] = None,
+        control_prompt: str = DEFAULT_CONTROL_AGENT_PROMPT,
+        worker_system_prompt: str = DEFAULT_WORKER_SYSTEM_PROMPT,
+    ) -> None:
+        self._worker_lock = threading.RLock()
+        self._workers = dict(workers)
+        if max_workers is not None and max_workers < 1:
+            raise ValueError("max_workers must be positive when provided")
+        self._max_workers = max_workers
+        self._log_enabled = log_enabled
+        self._log_sink = log_sink or print
+        self._agent_colors = {
+            worker_id: _AGENT_COLORS[index % len(_AGENT_COLORS)]
+            for index, worker_id in enumerate(self._workers)
+        }
+        self._control_prompt = control_prompt
+        self._worker_system_prompt = worker_system_prompt
+
+    def add_worker(self, turtle_id: str, worker: TurtleWorker) -> None:
+        """Register or replace the worker for ``turtle_id``."""
+        if not turtle_id:
+            raise ValueError("turtle_id must be non-empty")
+        with self._worker_lock:
+            self._workers[turtle_id] = worker
+            if turtle_id not in self._agent_colors:
+                color_index = len(self._agent_colors) % len(_AGENT_COLORS)
+                self._agent_colors[turtle_id] = _AGENT_COLORS[color_index]
+
+    def remove_worker(self, turtle_id: str) -> bool:
+        """Remove the worker for ``turtle_id`` and return whether one existed."""
+        with self._worker_lock:
+            removed = self._workers.pop(turtle_id, None) is not None
+            self._agent_colors.pop(turtle_id, None)
+            return removed
+
+    def worker_ids(self) -> Tuple[str, ...]:
+        """Return currently registered worker ids."""
+        with self._worker_lock:
+            return tuple(self._workers)
+
+    def run_parallel(
+        self,
+        tasks: Sequence[TurtleTask],
+        *,
+        timeout: Optional[float] = None,
+    ) -> Tuple[TurtleTaskResult, ...]:
+        """
+        Run turtle tasks concurrently and return results in input order.
+
+        Unknown turtles and worker exceptions become failed results instead of
+        interrupting unrelated turtle tasks.
+        """
+        if not tasks:
+            return tuple()
+
+        workers = self._snapshot_workers()
+        results: Dict[int, TurtleTaskResult] = {}
+        future_context: Dict[Future, Tuple[int, TurtleTask, float]] = {}
+        runnable_count = sum(1 for task in tasks if task.turtle_id in workers)
+        pool_size = self._pool_size(runnable_count, worker_count=len(workers))
+
+        if pool_size == 0:
+            return tuple(
+                self._unknown_turtle_result(task)
+                for task in tasks
+            )
+
+        with ThreadPoolExecutor(max_workers=pool_size) as executor:
+            for index, task in enumerate(tasks):
+                worker = workers.get(task.turtle_id)
+                if worker is None:
+                    results[index] = self._unknown_turtle_result(task)
+                    continue
+                started_at = monotonic()
+                self._log_start(task)
+                future = executor.submit(worker, task)
+                future_context[future] = (index, task, started_at)
+
+            try:
+                for future in as_completed(future_context, timeout=timeout):
+                    index, task, started_at = future_context[future]
+                    results[index] = self._result_from_future(future, task, started_at)
+                    self._log_result(results[index])
+            except TimeoutError:
+                for future, (index, task, started_at) in future_context.items():
+                    if future.done():
+                        results[index] = self._result_from_future(future, task, started_at)
+                    else:
+                        future.cancel()
+                        results[index] = TurtleTaskResult(
+                            turtle_id=task.turtle_id,
+                            ok=False,
+                            instruction=task.instruction,
+                            error="task timed out",
+                            elapsed_seconds=monotonic() - started_at,
+                            metadata=task.metadata,
+                        )
+                    self._log_result(results[index])
+
+        return tuple(results[index] for index in range(len(tasks)))
+
+    def run_prompt_queue(
+        self,
+        prompts: Sequence[str],
+        *,
+        timeout: Optional[float] = None,
+    ) -> Tuple[TurtleTaskResult, ...]:
+        """
+        Feed prompts to worker agents until the shared queue is exhausted.
+
+        A worker receives one prompt at a time. When it finishes successfully,
+        the control agent immediately assigns the next queued prompt to that
+        same worker. Failed workers are not reused, so other workers can keep
+        draining the queue.
+        """
+        workers = self._snapshot_workers()
+        if not prompts or not workers:
+            return tuple()
+
+        prompt_queue: Deque[Tuple[int, str]] = deque(enumerate(prompts))
+        worker_ids = list(workers)
+        pool_size = self._pool_size(
+            min(len(worker_ids), len(prompt_queue)),
+            worker_count=len(workers),
+        )
+        if pool_size == 0:
+            return tuple()
+
+        results: List[TurtleTaskResult] = []
+        future_context: Dict[Future, Tuple[str, TurtleTask, float]] = {}
+        deadline = None if timeout is None else monotonic() + timeout
+
+        def _submit_next(executor: ThreadPoolExecutor, worker_id: str) -> None:
+            prompt_index, prompt = prompt_queue.popleft()
+            task = TurtleTask(
+                turtle_id=worker_id,
+                instruction=prompt,
+                metadata={
+                    "prompt_index": prompt_index,
+                    "worker_system_prompt": self._worker_system_prompt,
+                },
+            )
+            started_at = monotonic()
+            self._log_start(task)
+            future = executor.submit(workers[worker_id], task)
+            future_context[future] = (worker_id, task, started_at)
+
+        with ThreadPoolExecutor(max_workers=pool_size) as executor:
+            for worker_id in worker_ids[:pool_size]:
+                if not prompt_queue:
+                    break
+                _submit_next(executor, worker_id)
+
+            while future_context:
+                wait_timeout = None
+                if deadline is not None:
+                    wait_timeout = max(0.0, deadline - monotonic())
+                    if wait_timeout == 0.0:
+                        self._mark_active_as_timed_out(future_context, results)
+                        break
+
+                done, _pending = wait(
+                    tuple(future_context),
+                    timeout=wait_timeout,
+                    return_when=FIRST_COMPLETED,
+                )
+                if not done:
+                    self._mark_active_as_timed_out(future_context, results)
+                    break
+
+                for future in done:
+                    worker_id, task, started_at = future_context.pop(future)
+                    result = self._result_from_future(future, task, started_at)
+                    results.append(result)
+                    self._log_result(result)
+                    if result.ok and prompt_queue:
+                        _submit_next(executor, worker_id)
+
+        while prompt_queue:
+            prompt_index, prompt = prompt_queue.popleft()
+            results.append(
+                TurtleTaskResult(
+                    turtle_id="",
+                    ok=False,
+                    instruction=prompt,
+                    error="no active worker available",
+                    metadata={"prompt_index": prompt_index},
+                )
+            )
+
+        return tuple(results)
+
+    def run_user_prompt(
+        self,
+        user_prompt: str,
+        llm_planner: Any,
+        *,
+        timeout: Optional[float] = None,
+    ) -> Tuple[TurtleTaskResult, ...]:
+        """
+        Call an LLM/planner to turn one user prompt into worker prompts, then run them.
+
+        `llm_planner` may be a callable (`planner(user_prompt)`) or a LangChain-like
+        object with `invoke(user_prompt)`. Tests can pass a fake planner; production
+        code can pass an actual LLM chain later.
+        """
+        self._log_llm_start(user_prompt)
+        try:
+            planner_prompt = self._build_control_prompt(user_prompt)
+            planned = self._invoke_planner(llm_planner, planner_prompt)
+            prompts = self._normalize_planned_prompts(planned)
+        except Exception as exc:
+            result = TurtleTaskResult(
+                turtle_id="control",
+                ok=False,
+                instruction=user_prompt,
+                error=f"planner failed: {type(exc).__name__}: {exc}",
+            )
+            self._log_result(result)
+            return (result,)
+
+        self._log_llm_result(user_prompt, prompts)
+        return self.run_prompt_queue(prompts, timeout=timeout)
+
+    def _build_control_prompt(self, user_prompt: str) -> str:
+        return self._control_prompt.format(user_prompt=user_prompt)
+
+    def _snapshot_workers(self) -> Dict[str, TurtleWorker]:
+        with self._worker_lock:
+            return dict(self._workers)
+
+    def _pool_size(self, runnable_count: int, *, worker_count: Optional[int] = None) -> int:
+        if runnable_count < 1:
+            return 0
+        if self._max_workers is not None:
+            return min(self._max_workers, runnable_count)
+        if worker_count is None:
+            worker_count = len(self._snapshot_workers())
+        return min(worker_count, runnable_count)
+
+    def _agent_label(self, turtle_id: str) -> str:
+        with self._worker_lock:
+            color = self._agent_colors.get(turtle_id, "")
+        label = f"[{turtle_id or 'unassigned'}]"
+        if not color:
+            return label
+        return f"{color}{label}{_ANSI_RESET}"
+
+    def _emit_log(self, message: str) -> None:
+        if self._log_enabled:
+            self._log_sink(message)
+
+    def _log_llm_start(self, _user_prompt: str) -> None:
+        self._emit_log("[control] planning worker prompts with LLM")
+
+    def _log_llm_result(self, _user_prompt: str, prompts: Sequence[str]) -> None:
+        self._emit_log(f"[control] planned {len(prompts)} worker prompts")
+        for index, _prompt in enumerate(prompts):
+            self._emit_log(f"[control] queued worker prompt#{index}")
+
+    def _log_start(self, task: TurtleTask) -> None:
+        task_ref = self._task_ref(task.metadata)
+        self._emit_log(
+            f"{self._agent_label(task.turtle_id)} invoking worker LLM {task_ref}"
+        )
+
+    def _log_result(self, result: TurtleTaskResult) -> None:
+        task_ref = self._task_ref(result.metadata)
+        if result.ok:
+            self._emit_log(
+                f"{self._agent_label(result.turtle_id)} completed worker task {task_ref}"
+            )
+            return
+        self._emit_log(
+            f"{self._agent_label(result.turtle_id)} worker task failed "
+            f"{task_ref}: {result.error}"
+        )
+
+    @staticmethod
+    def _task_ref(metadata: Dict[str, Any]) -> str:
+        prompt_index = metadata.get("prompt_index")
+        if prompt_index is None:
+            return ""
+        return f"prompt#{prompt_index}"
+
+    @staticmethod
+    def _invoke_planner(llm_planner: Any, user_prompt: str) -> Any:
+        invoke = getattr(llm_planner, "invoke", None)
+        if callable(invoke):
+            return invoke(user_prompt)
+        if callable(llm_planner):
+            return llm_planner(user_prompt)
+        raise TypeError("llm_planner must be callable or expose invoke(prompt)")
+
+    @staticmethod
+    def _normalize_planned_prompts(planned: Any) -> Tuple[str, ...]:
+        if isinstance(planned, str):
+            prompts = tuple(
+                TurtleControlAgent._clean_planned_prompt(line)
+                for line in planned.splitlines()
+                if TurtleControlAgent._clean_planned_prompt(line)
+            )
+        else:
+            prompts = tuple(
+                TurtleControlAgent._clean_planned_prompt(str(prompt))
+                for prompt in planned
+                if TurtleControlAgent._clean_planned_prompt(str(prompt))
+            )
+        if not prompts:
+            raise ValueError("planner returned no worker prompts")
+        return prompts
+
+    @staticmethod
+    def _clean_planned_prompt(prompt: str) -> str:
+        cleaned = prompt.strip()
+        cleaned = cleaned.removeprefix("-").strip()
+        cleaned = cleaned.removeprefix("*").strip()
+        if "." in cleaned:
+            prefix, rest = cleaned.split(".", 1)
+            if prefix.strip().isdigit():
+                cleaned = rest.strip()
+        return cleaned
+
+    @staticmethod
+    def _unknown_turtle_result(task: TurtleTask) -> TurtleTaskResult:
+        return TurtleTaskResult(
+            turtle_id=task.turtle_id,
+            ok=False,
+            instruction=task.instruction,
+            error=f"no worker registered for turtle '{task.turtle_id}'",
+            metadata=task.metadata,
+        )
+
+    @staticmethod
+    def _mark_active_as_timed_out(
+        future_context: Dict[Future, Tuple[str, TurtleTask, float]],
+        results: List[TurtleTaskResult],
+    ) -> None:
+        for future, (_worker_id, task, started_at) in tuple(future_context.items()):
+            if future.done():
+                results.append(
+                    TurtleControlAgent._result_from_future(future, task, started_at)
+                )
+            else:
+                future.cancel()
+                results.append(
+                    TurtleTaskResult(
+                        turtle_id=task.turtle_id,
+                        ok=False,
+                        instruction=task.instruction,
+                        error="task timed out",
+                        elapsed_seconds=monotonic() - started_at,
+                        metadata=task.metadata,
+                    )
+                )
+            future_context.pop(future, None)
+
+    @staticmethod
+    def _result_from_future(
+        future: Future,
+        task: TurtleTask,
+        started_at: float,
+    ) -> TurtleTaskResult:
+        elapsed = monotonic() - started_at
+        try:
+            output = future.result()
+        except Exception as exc:
+            return TurtleTaskResult(
+                turtle_id=task.turtle_id,
+                ok=False,
+                instruction=task.instruction,
+                error=f"{type(exc).__name__}: {exc}",
+                elapsed_seconds=elapsed,
+                metadata=task.metadata,
+            )
+        return TurtleTaskResult(
+            turtle_id=task.turtle_id,
+            ok=True,
+            instruction=task.instruction,
+            output=str(output),
+            elapsed_seconds=elapsed,
+            metadata=task.metadata,
+        )

--- a/src/turtle_agent/scripts/turtle_control_prompts.py
+++ b/src/turtle_agent/scripts/turtle_control_prompts.py
@@ -1,0 +1,46 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Prompts used by the turtle control agent."""
+
+CONTROL_AGENT_PROMPT = """당신은 여러 worker agent를 조율하는 컨트롤 에이전트입니다.
+
+당신의 역할은 사용자 요청 하나를 worker agent가 수행할 작업 큐로 변환하는 것입니다.
+
+규칙:
+- 작업을 직접 해결하지 마세요.
+- worker 작업만 생성하세요.
+- 각 worker 작업은 가능한 한 작고 독립적인 단위여야 합니다.
+- 사용자 요청에 출력 형식, 대상 turtle, 배정 규칙이 있으면 반드시 따르세요.
+- 특정 turtle이 지정되지 않은 작업은 사용 가능한 worker가 수행할 수 있게 작성하세요.
+- 각 줄은 worker 하나가 수행할 수 있는 작업 하나만 담아야 합니다.
+- turtlesim 좌표는 기본적으로 0 이상 11 이하 범위 안에서 계획하세요.
+- 설명, 요약, 부가 해설은 사용자 요청이 요구할 때만 출력하세요.
+
+사용자 요청:
+{user_prompt}
+"""
+
+WORKER_SYSTEM_PROMPT = """당신은 worker agent입니다.
+
+규칙:
+- 전달받은 task 하나만 수행하세요.
+- 전달받은 tool만 호출하세요.
+- 다른 도구를 호출하지 마세요.
+- 다른 worker에게 작업을 배정하지 마세요.
+- assigned_turtle이 전달되면 도구 호출의 name 인자에는 assigned_turtle만 사용하세요.
+- spawn 또는 kill 작업은 task에서 요청한 turtle 이름을 사용하세요.
+- 좌표를 사용하는 작업은 turtlesim 좌표 범위 안에서 수행하세요.
+- 결과만 간결하게 답하세요.
+"""

--- a/src/turtle_agent/scripts/turtle_control_runtime.py
+++ b/src/turtle_agent/scripts/turtle_control_runtime.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Runtime for running the control agent against a live turtlesim instance."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional, Sequence
+
+import rospy
+import tools.turtle as turtle_tools
+from geometry_msgs.msg import Twist
+from llm import get_llm
+from obstacle_store import ObstacleStore
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.panel import Panel
+from ros_params import get_bool_param
+from turtle_control_agent import TurtleControlAgent, TurtleTask, TurtleTaskResult
+from turtle_control_prompts import WORKER_SYSTEM_PROMPT
+
+try:
+    from langchain.agents import AgentExecutor, create_tool_calling_agent
+    from langchain.prompts import MessagesPlaceholder
+    from langchain_core.prompts import ChatPromptTemplate
+except ImportError:
+    AgentExecutor = None
+    ChatPromptTemplate = None
+    MessagesPlaceholder = None
+    create_tool_calling_agent = None
+
+
+_DEFAULT_PROMPT_LIMIT = 0
+_DEFAULT_TIMEOUT = 0.0
+
+
+class LangChainPlanner:
+    """Planner that turns a user request into line-delimited worker tasks."""
+
+    def __init__(self, *, task_count: int = _DEFAULT_PROMPT_LIMIT, streaming: bool = False) -> None:
+        self.task_count = task_count
+        self.llm = get_llm(streaming=streaming)
+
+    def invoke(self, control_prompt: str) -> str:
+        planner_prompt = control_prompt
+        if self.task_count > 0:
+            planner_prompt = (
+                f"{control_prompt}\n\n"
+                f"생성할 worker 작업 수는 최대 {self.task_count}개입니다."
+            )
+        response = self.llm.invoke(planner_prompt)
+        return _message_to_text(response)
+
+
+class TurtleSimWorker:
+    """LLM worker that operates one assigned turtle through turtlesim tools."""
+
+    def __init__(self, turtle_name: str, *, streaming: bool = False) -> None:
+        self.turtle_name = turtle_name
+        self.llm = get_llm(streaming=streaming)
+        self.tools = _turtlesim_tools()
+        self.executor = _build_worker_executor(
+            llm=self.llm,
+            tools=self.tools,
+            streaming=streaming,
+        )
+
+    def __call__(self, task: TurtleTask) -> str:
+        result = self.executor.invoke(
+            {
+                "worker_system_prompt": task.metadata.get(
+                    "worker_system_prompt",
+                    WORKER_SYSTEM_PROMPT,
+                ),
+                "turtle_name": self.turtle_name,
+                "input": task.instruction,
+            }
+        )
+        if isinstance(result, dict) and "output" in result:
+            return str(result["output"])
+        return _message_to_text(result)
+
+
+def run_turtle_control_agent(
+    *,
+    obstacle_store: Optional[ObstacleStore] = None,
+    lifecycle_listener: Optional[Any] = None,
+) -> None:
+    """Run the interactive control-agent loop inside the initialized ROS node."""
+    _ = obstacle_store
+    console = Console()
+    streaming = get_bool_param("~streaming", False)
+    worker_count = _get_int_param("~control_worker_count", 2)
+    task_count = _get_int_param("~control_task_count", _DEFAULT_PROMPT_LIMIT)
+    timeout = _get_float_param("~control_task_timeout", _DEFAULT_TIMEOUT)
+    reset_turtlesim = get_bool_param("~control_reset_turtlesim", False)
+
+    turtle_names = _turtle_names(worker_count)
+    planner = LangChainPlanner(task_count=task_count, streaming=streaming)
+    control_agent = TurtleControlAgent({}, log_enabled=False)
+    control_lifecycle = TurtleControlLifecycleListener(
+        control_agent,
+        worker_factory=lambda turtle_name: TurtleSimWorker(
+            turtle_name,
+            streaming=streaming,
+        ),
+    )
+    turtle_tools.configure_turtle_lifecycle_listener(
+        CompositeTurtleLifecycleListener(lifecycle_listener, control_lifecycle)
+    )
+    _prepare_turtles(turtle_names, reset_turtlesim=reset_turtlesim)
+    for turtle_name in turtle_names:
+        control_lifecycle.on_turtle_spawned(turtle_name)
+
+    console.print(
+        Panel(
+            Markdown(
+                "Turtle control mode is running.\n\n"
+                "- Type a drawing request to split it into worker tasks.\n"
+                "- Type `exit` to quit."
+            ),
+            title="ROSA Turtle Control",
+            border_style="green",
+        )
+    )
+
+    while not rospy.is_shutdown():
+        try:
+            user_prompt = input("> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            console.print("\n[Shutdown complete]")
+            break
+        if not user_prompt:
+            continue
+        if user_prompt == "exit":
+            break
+
+        results = control_agent.run_user_prompt(
+            user_prompt,
+            planner,
+            timeout=None if timeout <= 0 else timeout,
+        )
+        _print_results(console, results)
+
+
+class TurtleControlLifecycleListener:
+    """Keep a control-agent worker registry in sync with turtle lifecycle events."""
+
+    def __init__(
+        self,
+        control_agent: TurtleControlAgent,
+        *,
+        worker_factory: Callable[[str], TurtleSimWorker],
+    ) -> None:
+        self._control_agent = control_agent
+        self._worker_factory = worker_factory
+
+    def on_turtle_spawned(self, name: str) -> None:
+        turtle_name = _normalize_turtle_name(name)
+        if not turtle_name:
+            return
+        if turtle_name in self._control_agent.worker_ids():
+            turtle_tools.add_cmd_vel_pub(
+                turtle_name,
+                rospy.Publisher(f"/{turtle_name}/cmd_vel", Twist, queue_size=10),
+            )
+            return
+        self._control_agent.add_worker(
+            turtle_name,
+            self._worker_factory(turtle_name),
+        )
+        turtle_tools.add_cmd_vel_pub(
+            turtle_name,
+            rospy.Publisher(f"/{turtle_name}/cmd_vel", Twist, queue_size=10),
+        )
+
+    def on_turtle_killed(self, name: str) -> None:
+        turtle_name = _normalize_turtle_name(name)
+        if not turtle_name:
+            return
+        self._control_agent.remove_worker(turtle_name)
+        turtle_tools.remove_cmd_vel_pub(turtle_name)
+
+
+class CompositeTurtleLifecycleListener:
+    """Fan out turtle lifecycle notifications to multiple listeners."""
+
+    def __init__(self, *listeners: Optional[Any]) -> None:
+        self._listeners = tuple(listener for listener in listeners if listener is not None)
+
+    def on_turtle_spawned(self, name: str) -> None:
+        for listener in self._listeners:
+            listener.on_turtle_spawned(name)
+
+    def on_turtle_killed(self, name: str) -> None:
+        for listener in self._listeners:
+            listener.on_turtle_killed(name)
+
+
+def _build_worker_executor(llm: Any, tools: Sequence[Any], streaming: bool) -> Any:
+    if not _tool_calling_available():
+        raise RuntimeError("LangChain tool-calling agent dependencies are unavailable.")
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            ("system", "{worker_system_prompt}"),
+            (
+                "human",
+                "assigned_turtle: {turtle_name}\n"
+                "task: {input}\n\n"
+                "Use assigned_turtle as the `name` argument for movement and drawing "
+                "tools. Spawn and kill tools may use the turtle name requested by "
+                "the task.",
+            ),
+            MessagesPlaceholder(variable_name="agent_scratchpad"),
+        ]
+    )
+    agent = create_tool_calling_agent(
+        llm=llm.with_config({"streaming": streaming}),
+        tools=tools,
+        prompt=prompt,
+    )
+    return AgentExecutor(
+        agent=agent,
+        tools=tools,
+        stream_runnable=streaming,
+        verbose=False,
+        max_iterations=20,
+        handle_parsing_errors=True,
+    )
+
+
+def _tool_calling_available() -> bool:
+    return all(
+        item is not None
+        for item in (
+            AgentExecutor,
+            ChatPromptTemplate,
+            MessagesPlaceholder,
+            create_tool_calling_agent,
+        )
+    )
+
+
+def _turtlesim_tools() -> list[Any]:
+    return [
+        turtle_tools.spawn_turtle,
+        turtle_tools.kill_turtle,
+        turtle_tools.clear_turtlesim,
+        turtle_tools.get_turtle_pose,
+        turtle_tools.teleport_absolute,
+        turtle_tools.teleport_relative,
+        turtle_tools.publish_twist_to_cmd_vel,
+        turtle_tools.stop_turtle,
+        turtle_tools.set_pen,
+        turtle_tools.has_moved_to_expected_coordinates,
+        turtle_tools.draw_line_segment,
+        turtle_tools.draw_rectangle,
+        turtle_tools.draw_polyline,
+        turtle_tools.calculate_rectangle_bounds,
+        turtle_tools.check_rectangles_overlap,
+        turtle_tools.draw_circle,
+        turtle_tools.draw_arc,
+    ]
+
+
+def _prepare_turtles(turtle_names: Sequence[str], *, reset_turtlesim: bool) -> None:
+    if reset_turtlesim:
+        rospy.loginfo("%s", turtle_tools.reset_turtlesim.invoke({}))
+
+    for index, turtle_name in enumerate(turtle_names):
+        if turtle_name != "turtle1":
+            x, y = _spawn_position(index)
+            result = turtle_tools.spawn_turtle.invoke(
+                {
+                    "name": turtle_name,
+                    "x": x,
+                    "y": y,
+                    "theta": 0.0,
+                }
+            )
+            rospy.loginfo("%s", result)
+
+
+def _spawn_position(index: int) -> tuple[float, float]:
+    positions = (
+        (5.5, 5.5),
+        (2.0, 2.0),
+        (9.0, 2.0),
+        (2.0, 9.0),
+        (9.0, 9.0),
+    )
+    return positions[index % len(positions)]
+
+
+def _turtle_names(worker_count: int) -> tuple[str, ...]:
+    names_param = str(rospy.get_param("~control_turtle_names", "")).strip()
+    if names_param:
+        names = tuple(name.strip().strip("/") for name in names_param.split(",") if name.strip())
+        if names:
+            return names
+    return tuple(f"turtle{index}" for index in range(1, max(worker_count, 1) + 1))
+
+
+def _normalize_turtle_name(name: str) -> str:
+    return str(name).strip().replace("/", "")
+
+
+def _get_int_param(name: str, default: int) -> int:
+    try:
+        return int(rospy.get_param(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _get_float_param(name: str, default: float) -> float:
+    try:
+        return float(rospy.get_param(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _print_results(console: Console, results: Sequence[TurtleTaskResult]) -> None:
+    lines = []
+    for result in results:
+        status = "ok" if result.ok else "failed"
+        detail = result.output if result.ok else result.error
+        lines.append(f"- `{result.turtle_id}` {status}: {detail}")
+    console.print(Panel(Markdown("\n".join(lines)), title="Worker Results"))
+
+
+def _message_to_text(response: Any) -> str:
+    content = getattr(response, "content", response)
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        chunks = []
+        for item in content:
+            if isinstance(item, str):
+                chunks.append(item)
+            elif isinstance(item, dict):
+                chunks.append(str(item.get("text", "")))
+            else:
+                chunks.append(str(item))
+        return "\n".join(chunk for chunk in chunks if chunk.strip())
+    return str(content)

--- a/tests/test_turtle_agent/test_turtle_control_agent.py
+++ b/tests/test_turtle_agent/test_turtle_control_agent.py
@@ -1,0 +1,315 @@
+#  Copyright (c) 2024. Jet Propulsion Laboratory. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+
+import sys
+import threading
+import time
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "src" / "turtle_agent" / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+from turtle_control_agent import (  # noqa: E402
+    DEFAULT_WORKER_SYSTEM_PROMPT,
+    TurtleControlAgent,
+    TurtleTask,
+)
+from turtle_control_prompts import WORKER_SYSTEM_PROMPT  # noqa: E402
+
+
+def _plan_segment_prompts(_user_prompt, count):
+    return [
+        f"선분 {index}을 그리시오"
+        for index in range(count)
+    ]
+
+
+def _make_recording_worker(log, lock, delay=0.0, fail_first=False):
+    calls = {"count": 0}
+
+    def worker(task):
+        with lock:
+            calls["count"] += 1
+            call_number = calls["count"]
+            log.append((task.turtle_id, task.instruction, time.monotonic()))
+        if fail_first and call_number == 1:
+            raise RuntimeError(f"{task.turtle_id} planned failure")
+        if delay:
+            time.sleep(delay)
+        return f"{task.turtle_id}: received {task.instruction}"
+
+    return worker
+
+
+class FakeLlmPlanner:
+    def __init__(self, prompts):
+        self.prompts = tuple(prompts)
+        self.calls = []
+
+    def invoke(self, user_prompt):
+        self.calls.append(user_prompt)
+        return self.prompts
+
+
+class TestTurtleControlAgent(unittest.TestCase):
+    def test_default_worker_system_prompt_matches_task_policy(self):
+        self.assertEqual(DEFAULT_WORKER_SYSTEM_PROMPT, WORKER_SYSTEM_PROMPT)
+        self.assertIn("worker agent", DEFAULT_WORKER_SYSTEM_PROMPT)
+        self.assertIn("전달받은 task 하나만 수행", DEFAULT_WORKER_SYSTEM_PROMPT)
+        self.assertIn("결과만 간결하게 답하세요", DEFAULT_WORKER_SYSTEM_PROMPT)
+
+    def test_runs_workers_in_parallel(self):
+        barrier = threading.Barrier(2)
+        starts = []
+        lock = threading.Lock()
+
+        def make_worker(label):
+            def worker(task):
+                with lock:
+                    starts.append((label, time.monotonic()))
+                barrier.wait(timeout=1.0)
+                time.sleep(0.02)
+                return f"{task.turtle_id}:{task.instruction}"
+
+            return worker
+
+        control = TurtleControlAgent(
+            {
+                "turtle1": make_worker("turtle1"),
+                "turtle2": make_worker("turtle2"),
+            }
+        )
+
+        results = control.run_parallel(
+            [
+                TurtleTask("turtle1", "draw left edge"),
+                TurtleTask("turtle2", "draw right edge"),
+            ]
+        )
+
+        self.assertEqual([r.ok for r in results], [True, True])
+        self.assertEqual(results[0].output, "turtle1:draw left edge")
+        self.assertEqual(results[1].output, "turtle2:draw right edge")
+        self.assertEqual({name for name, _ in starts}, {"turtle1", "turtle2"})
+        self.assertLess(abs(starts[0][1] - starts[1][1]), 0.2)
+
+    def test_worker_failure_is_isolated(self):
+        def ok_worker(task):
+            return f"done:{task.instruction}"
+
+        def failing_worker(_task):
+            raise RuntimeError("boom")
+
+        control = TurtleControlAgent(
+            {
+                "turtle1": failing_worker,
+                "turtle2": ok_worker,
+            }
+        )
+
+        results = control.run_parallel(
+            [
+                TurtleTask("turtle1", "bad task"),
+                TurtleTask("turtle2", "good task"),
+            ]
+        )
+
+        self.assertFalse(results[0].ok)
+        self.assertIn("RuntimeError: boom", results[0].error)
+        self.assertTrue(results[1].ok)
+        self.assertEqual(results[1].output, "done:good task")
+
+    def test_unknown_turtle_returns_failed_result(self):
+        control = TurtleControlAgent({"turtle1": lambda task: task.instruction})
+
+        results = control.run_parallel(
+            [
+                TurtleTask("turtle3", "unassigned"),
+                TurtleTask("turtle1", "assigned"),
+            ]
+        )
+
+        self.assertFalse(results[0].ok)
+        self.assertIn("no worker registered", results[0].error)
+        self.assertTrue(results[1].ok)
+        self.assertEqual(results[1].output, "assigned")
+
+    def test_add_worker_registers_new_turtle_for_future_tasks(self):
+        control = TurtleControlAgent({"turtle1": lambda task: f"one:{task.instruction}"})
+
+        control.add_worker("turtle2", lambda task: f"two:{task.instruction}")
+
+        self.assertEqual(control.worker_ids(), ("turtle1", "turtle2"))
+        results = control.run_parallel([TurtleTask("turtle2", "draw circle")])
+        self.assertTrue(results[0].ok)
+        self.assertEqual(results[0].output, "two:draw circle")
+
+    def test_remove_worker_unassigns_turtle_for_future_tasks(self):
+        control = TurtleControlAgent(
+            {
+                "turtle1": lambda task: f"one:{task.instruction}",
+                "turtle2": lambda task: f"two:{task.instruction}",
+            }
+        )
+
+        self.assertTrue(control.remove_worker("turtle2"))
+        self.assertFalse(control.remove_worker("turtle2"))
+
+        results = control.run_parallel([TurtleTask("turtle2", "draw circle")])
+        self.assertFalse(results[0].ok)
+        self.assertIn("no worker registered", results[0].error)
+
+    def test_timeout_marks_unfinished_tasks(self):
+        started = threading.Event()
+
+        def slow_worker(_task):
+            started.set()
+            time.sleep(0.2)
+            return "late"
+
+        control = TurtleControlAgent({"turtle1": slow_worker})
+
+        results = control.run_parallel([TurtleTask("turtle1", "slow")], timeout=0.01)
+
+        self.assertTrue(started.is_set())
+        self.assertFalse(results[0].ok)
+        self.assertEqual(results[0].error, "task timed out")
+
+    def test_plans_segment_prompts_from_user_prompt(self):
+        prompts = _plan_segment_prompts("정사각형의 각 변을 그리시오", count=4)
+
+        self.assertEqual(
+            prompts,
+            [
+                "선분 0을 그리시오",
+                "선분 1을 그리시오",
+                "선분 2을 그리시오",
+                "선분 3을 그리시오",
+            ],
+        )
+
+    def test_normalizes_llm_planned_prompt_text(self):
+        planned = TurtleControlAgent._normalize_planned_prompts(
+            "- 왼쪽 변을 그리시오\n1. 오른쪽 변을 그리시오"
+        )
+
+        self.assertEqual(
+            planned,
+            (
+                "왼쪽 변을 그리시오",
+                "오른쪽 변을 그리시오",
+            ),
+        )
+
+    def test_prompt_queue_assigns_next_prompt_to_completed_agent(self):
+        log = []
+        output_lines = []
+        lock = threading.Lock()
+        control = TurtleControlAgent(
+            {
+                "turtle1": _make_recording_worker(log, lock, delay=0.005),
+                "turtle2": _make_recording_worker(log, lock, delay=0.05),
+            },
+            log_enabled=True,
+            log_sink=output_lines.append,
+        )
+        prompts = _plan_segment_prompts("도형을 선분으로 나누어 그리시오", count=5)
+
+        results = control.run_prompt_queue(prompts)
+
+        self.assertEqual(len(results), 5)
+        self.assertTrue(all(result.ok for result in results))
+        outputs = {result.instruction: result.output for result in results}
+        self.assertIn("received 선분 0을 그리시오", outputs["선분 0을 그리시오"])
+        self.assertIn("received 선분 1을 그리시오", outputs["선분 1을 그리시오"])
+        assigned_by_turtle = {}
+        for turtle_id, _instruction, _started_at in log:
+            assigned_by_turtle[turtle_id] = assigned_by_turtle.get(turtle_id, 0) + 1
+        self.assertGreater(assigned_by_turtle["turtle1"], assigned_by_turtle["turtle2"])
+        self.assertEqual(
+            sorted(result.metadata["prompt_index"] for result in results),
+            list(range(5)),
+        )
+        joined_logs = "\n".join(output_lines)
+        self.assertIn("invoking worker LLM prompt#0", joined_logs)
+        self.assertIn("completed worker task prompt#0", joined_logs)
+        self.assertIn("\033[36m[turtle1]\033[0m", joined_logs)
+        self.assertIn("\033[35m[turtle2]\033[0m", joined_logs)
+        self.assertIn("worker_system_prompt", results[0].metadata)
+
+    def test_prompt_queue_failure_does_not_stop_other_agents(self):
+        log = []
+        lock = threading.Lock()
+        control = TurtleControlAgent(
+            {
+                "turtle1": _make_recording_worker(log, lock, fail_first=True),
+                "turtle2": _make_recording_worker(log, lock),
+            }
+        )
+        prompts = _plan_segment_prompts("세 개의 선분을 그리시오", count=3)
+
+        results = control.run_prompt_queue(prompts)
+
+        failures = [result for result in results if not result.ok]
+        successes = [result for result in results if result.ok]
+        self.assertEqual(len(failures), 1)
+        self.assertIn("RuntimeError", failures[0].error)
+        self.assertEqual(len(successes), 2)
+        self.assertTrue(all("turtle2:" in result.output for result in successes))
+        self.assertEqual(
+            sorted(result.metadata["prompt_index"] for result in results),
+            [0, 1, 2],
+        )
+
+    def test_user_prompt_calls_llm_planner_then_runs_prompt_queue(self):
+        log = []
+        output_lines = []
+        lock = threading.Lock()
+        planner = FakeLlmPlanner(
+            _plan_segment_prompts("삼각형을 선분으로 나누어 그리시오", count=3)
+        )
+        control = TurtleControlAgent(
+            {
+                "turtle1": _make_recording_worker(log, lock),
+                "turtle2": _make_recording_worker(log, lock),
+            },
+            log_enabled=True,
+            log_sink=output_lines.append,
+        )
+
+        results = control.run_user_prompt("삼각형을 선분으로 나누어 그리시오", planner)
+
+        self.assertEqual(len(planner.calls), 1)
+        self.assertIn("여러 worker agent를 조율하는 컨트롤 에이전트", planner.calls[0])
+        self.assertIn("사용자 요청:\n삼각형을 선분으로 나누어 그리시오", planner.calls[0])
+        self.assertEqual(len(results), 3)
+        self.assertTrue(all(result.ok for result in results))
+        outputs = {result.instruction: result.output for result in results}
+        self.assertIn("received 선분 0을 그리시오", outputs["선분 0을 그리시오"])
+        self.assertIn("received 선분 2을 그리시오", outputs["선분 2을 그리시오"])
+        joined_logs = "\n".join(output_lines)
+        self.assertIn("[control] planning worker prompts with LLM", joined_logs)
+        self.assertIn("[control] planned 3 worker prompts", joined_logs)
+        self.assertIn("[control] queued worker prompt#0", joined_logs)
+
+    def test_user_prompt_reports_planner_failure(self):
+        class FailingPlanner:
+            def invoke(self, _user_prompt):
+                raise RuntimeError("llm unavailable")
+
+        control = TurtleControlAgent({"turtle1": lambda task: task.instruction})
+
+        results = control.run_user_prompt("정사각형을 그리시오", FailingPlanner())
+
+        self.assertEqual(len(results), 1)
+        self.assertFalse(results[0].ok)
+        self.assertEqual(results[0].turtle_id, "control")
+        self.assertIn("planner failed: RuntimeError: llm unavailable", results[0].error)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 내용

- 기존 `turtle_agent.py` 진입점과 `agent.launch` 실행 흐름을 유지하면서 `agent_mode:=control` 모드를 추가했습니다.
- `turtle_control_runtime.py`를 추가해 컨트롤 에이전트가 사용자 요청을 worker 작업으로 분해하고, 각 `TurtleSimWorker`가 실제 `tools.turtle` 도구로 turtlesim을 조작하도록 연결했습니다.
- `spawn_turtle` / `kill_turtle` lifecycle 콜백을 통해 런타임 중 생성·삭제된 turtle을 worker registry에 동기화하도록 구현했습니다.
- 기존 기능 테스트용 산술/피보나치 데모 코드를 제거하고, 컨트롤 에이전트의 병렬 큐·실패 격리·동적 worker 등록/제거 단위 테스트로 정리했습니다.

## 실행 방법

기존 모드:

```bash
roslaunch turtle_agent agent.launch
```

컨트롤 모드:

```bash
roslaunch turtle_agent agent.launch agent_mode:=control
```

선택 파라미터:

```bash
roslaunch turtle_agent agent.launch agent_mode:=control control_worker_count:=2
```

## 테스트

- [x] `uv run ruff check src/turtle_agent/scripts/turtle_control_agent.py src/turtle_agent/scripts/turtle_control_runtime.py src/turtle_agent/scripts/turtle_control_prompts.py tests/test_turtle_agent/test_turtle_control_agent.py`
- [x] `python3 -m unittest tests/test_turtle_agent/test_turtle_control_agent.py`
- [x] `python3 -m py_compile src/turtle_agent/scripts/turtle_control_agent.py src/turtle_agent/scripts/turtle_control_runtime.py src/turtle_agent/scripts/turtle_control_prompts.py src/turtle_agent/scripts/turtle_agent.py`

## 관련 이슈

- Closes #26

Made with [Cursor](https://cursor.com)