### PR TITLE
feat: 정적 맵 static/ephemeral 로드, 터틀심 샘플 및 충돌 로그 필드

### DIFF
--- a/src/turtle_agent/config/static_obstacles_turtlesim.yaml
+++ b/src/turtle_agent/config/static_obstacles_turtlesim.yaml
@@ -1,5 +1,5 @@
-# Turtlesim default window: x and y span [0, 11] (inclusive). Walls as four edges
-# for use with circle-vs-segment collision checks (collision_geometry.any_segment_intersects_disc).
+# Turtlesim default window: x and y span [0, 11] (inclusive). Walls as four edges.
+# wet-*: side-1 AABB. a–d-point: circles diameter 0.5 (r=0.25) on inner corners; walls use segment-vs-disc checks.
 obstacles:
   - id: wall-south
     kind: static
@@ -25,32 +25,58 @@ obstacles:
       type: segments
       segments:
         - [ [ 0.0, 11.0 ], [ 0.0, 0.0 ] ]
-  - id: wet
-    kind: static
+  # Wet markers: side-1 squares; kind ephemeral (optional ttl_seconds; else loader default).
+  - id: wet-top
+    kind: ephemeral
     geometry:
       type: aabb
-      min_x: 5.0
-      min_y: 4.0
-      max_x: 7.0
-      max_y: 6.0
+      min_x: 4.5
+      min_y: 8.5
+      max_x: 5.5
+      max_y: 9.5
+  - id: wet-right
+    kind: ephemeral
+    geometry:
+      type: aabb
+      min_x: 8.5
+      min_y: 4.5
+      max_x: 9.5
+      max_y: 5.5
+  - id: wet-bottom
+    kind: ephemeral
+    geometry:
+      type: aabb
+      min_x: 4.5
+      min_y: 1.5
+      max_x: 5.5
+      max_y: 2.5
+  # Inner rect tlbr: left=2, top(y)=9, right=9, bottom(y)=2.
+  # a→b→c→d = 시계방향: SW(2,2) → SE(9,2) → NE(9,9) → NW(2,9) — 지름 0.5 원 (r=0.25)
   - id: a-point
     kind: static
     geometry:
       type: circle
-      cx: 1.0
-      cy: 5.0
+      cx: 2.0
+      cy: 2.0
       r: 0.25
   - id: b-point
     kind: static
     geometry:
       type: circle
-      cx: 10.0
-      cy: 5.0
+      cx: 9.0
+      cy: 2.0
       r: 0.25
   - id: c-point
     kind: static
     geometry:
       type: circle
-      cx: 6.0
-      cy: 7.0
+      cx: 9.0
+      cy: 9.0
+      r: 0.25
+  - id: d-point
+    kind: static
+    geometry:
+      type: circle
+      cx: 2.0
+      cy: 9.0
       r: 0.25

--- a/src/turtle_agent/scripts/static_map_loader.py
+++ b/src/turtle_agent/scripts/static_map_loader.py
@@ -37,6 +37,7 @@ Field mapping (file keys → :mod:`obstacle_store` types):
     :class:`SegmentsGeometry` (same tuple layout as :class:`collision_geometry.Segment`)
 
 **Duplicate ids:** default ``on_duplicate_id=\"replace\"`` matches :meth:`ObstacleStore.upsert`
+(last write wins). With ``on_duplicate_id=\"error\"``, a duplicate id in the store
 (or duplicated earlier in the same document) raises :exc:`StaticMapLoadError`.
 
 **Files:** :func:`load_file` uses the path suffix (``.yaml``/``.yml`` → PyYAML,

--- a/src/turtle_agent/scripts/static_map_loader.py
+++ b/src/turtle_agent/scripts/static_map_loader.py
@@ -27,8 +27,8 @@ YAML/JSON document shape::
 Field mapping (file keys → :mod:`obstacle_store` types):
 
 - ``id`` (str, required) → :attr:`Obstacle.id`
-- ``kind`` (str, optional) → :attr:`Obstacle.kind`; must be ``\"static\"`` if set.
-  Omitted defaults to ``\"static\"``.
+- ``kind``: ``\"static\"`` (default) or ``\"ephemeral\"``. Ephemeral deadlines use
+  ``ttl_seconds`` if given, else :data:`DEFAULT_EPHEMERAL_TTL_SECONDS` at load time.
 - ``geometry.type``:
 
   - ``circle`` — keys ``cx``, ``cy``, ``r`` (numbers) → :class:`CircleGeometry`
@@ -36,10 +36,7 @@ Field mapping (file keys → :mod:`obstacle_store` types):
   - ``segments`` — ``segments`` is a list of ``[[x1,y1],[x2,y2]]`` pairs →
     :class:`SegmentsGeometry` (same tuple layout as :class:`collision_geometry.Segment`)
 
-- ``expires_at`` is not supported here; static obstacles use ``expires_at=None``.
-
 **Duplicate ids:** default ``on_duplicate_id=\"replace\"`` matches :meth:`ObstacleStore.upsert`
-(last write wins). With ``on_duplicate_id=\"error\"``, an id already present in the store
 (or duplicated earlier in the same document) raises :exc:`StaticMapLoadError`.
 
 **Files:** :func:`load_file` uses the path suffix (``.yaml``/``.yml`` → PyYAML,
@@ -49,6 +46,7 @@ Field mapping (file keys → :mod:`obstacle_store` types):
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 from typing import (
     Any,
@@ -74,6 +72,9 @@ from obstacle_store import (
 )
 
 OnDuplicateId = Literal["replace", "error"]
+
+# Used when ``kind: ephemeral`` and ``ttl_seconds`` is omitted (seconds).
+DEFAULT_EPHEMERAL_TTL_SECONDS = 31_536_000.0
 
 
 class StaticMapLoadError(ValueError):
@@ -192,16 +193,36 @@ def _parse_obstacle_entry(raw: Any, *, source: Optional[str], index: int) -> Obs
     if not isinstance(kind, str):
         raise _err("kind must be a string", source=source, index=index)
     kind_l = kind.strip().lower()
-    if kind_l != "static":
+    if kind_l not in ("static", "ephemeral"):
         raise _err(
-            f"only static obstacles are supported, got kind={kind!r}",
+            f"map kind must be 'static' or 'ephemeral', got {kind!r}",
             source=source,
             index=index,
         )
     if "geometry" not in raw:
         raise _err("geometry is required", source=source, index=index)
     geometry = _parse_geometry(raw["geometry"], source=source, index=index)
-    return Obstacle(id=oid.strip(), kind="static", geometry=geometry, expires_at=None)
+    if kind_l == "static":
+        return Obstacle(
+            id=oid.strip(),
+            kind="static",
+            geometry=geometry,
+            expires_at=None,
+        )
+    raw_ttl = raw.get("ttl_seconds", DEFAULT_EPHEMERAL_TTL_SECONDS)
+    ttl = _coerce_float(raw_ttl, key="ttl_seconds", source=source, index=index)
+    if ttl <= 0:
+        raise _err(
+            "ttl_seconds must be positive for ephemeral obstacles",
+            source=source,
+            index=index,
+        )
+    return Obstacle(
+        id=oid.strip(),
+        kind="ephemeral",
+        geometry=geometry,
+        expires_at=time.monotonic() + ttl,
+    )
 
 
 def load_into_store(
@@ -310,7 +331,6 @@ def load_from_rosparam(
         )
     return load_into_store(
         store,
-        
         data,
         on_duplicate_id=on_duplicate_id,
         source=f"rosparam:{param_name}",

--- a/tests/test_turtle_agent/test_static_map_loader.py
+++ b/tests/test_turtle_agent/test_static_map_loader.py
@@ -203,12 +203,54 @@ class TestStaticMapLoader(unittest.TestCase):
         finally:
             Path(path).unlink(missing_ok=True)
 
+    def test_ephemeral_kind_without_ttl_uses_default(self):
+        store = ObstacleStore()
+        load_into_store(
+            store,
+            {
+                "obstacles": [
+                    {
+                        "id": "e",
+                        "kind": "ephemeral",
+                        "geometry": {"type": "circle", "cx": 0.0, "cy": 0.0, "r": 0.1},
+                    }
+                ]
+            },
+        )
+        o = store.get("e")
+        assert o is not None
+        self.assertEqual(o.kind, "ephemeral")
+        self.assertIsNotNone(o.expires_at)
+
+    def test_ephemeral_explicit_ttl_seconds(self):
+        import time as _time
+
+        store = ObstacleStore()
+        before = _time.monotonic()
+        load_into_store(
+            store,
+            {
+                "obstacles": [
+                    {
+                        "id": "e",
+                        "kind": "ephemeral",
+                        "ttl_seconds": 30.0,
+                        "geometry": {"type": "circle", "cx": 0, "cy": 0, "r": 0.1},
+                    }
+                ]
+            },
+        )
+        o = store.get("e")
+        assert o is not None
+        self.assertGreater(o.expires_at, before + 29.0)
+        self.assertLess(o.expires_at, before + 31.0)
+
     def test_sample_config_repo_path(self):
         sample = _CONFIG / "static_obstacles_turtlesim.yaml"
         self.assertTrue(sample.is_file(), msg=f"missing {sample}")
         store = ObstacleStore()
         n = load_file(store, sample)
-        self.assertEqual(n, 8)
+        self.assertEqual(n, 11)
         ids = {o.id for o in store.snapshot()}
         self.assertEqual(
             ids,
@@ -217,12 +259,19 @@ class TestStaticMapLoader(unittest.TestCase):
                 "wall-east",
                 "wall-north",
                 "wall-west",
-                "wet",
+                "wet-top",
+                "wet-right",
+                "wet-bottom",
                 "a-point",
                 "b-point",
                 "c-point",
+                "d-point",
             },
         )
+        wet = store.get("wet-top")
+        assert wet is not None
+        self.assertEqual(wet.kind, "ephemeral")
+        self.assertIsNotNone(wet.expires_at)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 배경·목표

거북이가 장애물과 겹칠 때 **어느 구역인지**, **영구(`static`)** 인지 **만료되는 `ephemeral`** 인지를 로그·후처리에서 구분할 수 있게 합니다. 맵 `kind`는 **`static`** / **`ephemeral`** 만 사용하고, 충돌 이벤트에 **구역 식별자**와 **`Obstacle.kind`** 가 함께 남도록 맞춥니다.

요구 정리: [#32](https://github.com/upstage-sesac-agentic-robotics/rosa/issues/32)

## 변경 요약

### 정적 맵 로더 (`static_map_loader.py`)

- 항목 `kind`는 **`static`**(기본)·**`ephemeral`** 만 허용. 그 외는 `StaticMapLoadError`.
- **`ephemeral`:** `ttl_seconds`가 있으면 그 값, 없으면 `DEFAULT_EPHEMERAL_TTL_SECONDS`(31_536_000초 ≈ 1년)으로 로드 시점 기준 `expires_at` 설정.
- 기하: `circle` / `aabb` / `segments` — `ObstacleStore.upsert`와 동일 규약.

### 샘플 맵 (`static_obstacles_turtlesim.yaml`)

- 테두리 `wall-*`: `static`, `segments` (0–11).
- 습지 마커 `wet-top` / `wet-right` / `wet-bottom`: **`ephemeral`**, 변 길이 1 `aabb` (`ttl_seconds` 생략 시 로더 기본 TTL).
- 내부 꼭짓점 `a-point`~`d-point`: `static`, 지름 0.5 원(`r: 0.25`), 중심 시계방향 SW→SE→NE→NW.

### 충돌 로그 (`collision_monitor.py` → `collision.jsonl`)

- `turtle_obstacle` 이벤트 `details`:
  - **`obstacle_kind`:** `Obstacle.kind` (`static` / `ephemeral`)
  - **`geometry`:** 기하 클래스 이름(예: `CircleGeometry`, `AabbGeometry`, `SegmentsGeometry`)

런치에서 `~static_obstacles_file`로 경로를 주면 `static_world.load_static_world`가 `ObstacleStore`에 맵을 올립니다(`agent.launch` 등).

### 테스트

- `tests/test_turtle_agent/test_static_map_loader.py` — `ephemeral` 기본·명시 TTL, 샘플 맵 id 등.

## 관련 이슈

- [#32](https://github.com/upstage-sesac-agentic-robotics/rosa/issues/32)
- 부모 로드맵: [#4](https://github.com/upstage-sesac-agentic-robotics/rosa/issues/4)

## 테스트

```bash
uv run python -m unittest tests.test_turtle_agent.test_static_map_loader -v
```

## 참고

- 작업 브랜치는 `dev` 최신 기준으로 맵 관련 변경만 분리한 이력입니다. 다른 브랜치 변경과는 stash로 구분했습니다.
