### PR TITLE
feat(turtle-agent): collision 로그를 short/long 메모리 증거로 연결 (#16)

### DIFF
--- a/src/turtle_agent/scripts/memory_converter.py
+++ b/src/turtle_agent/scripts/memory_converter.py
@@ -7,7 +7,12 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from command_logger import build_command_log_path
-from pose_logger import build_location_log_path, build_log_dir, resolve_log_root
+from pose_logger import (
+    build_collision_log_path,
+    build_location_log_path,
+    build_log_dir,
+    resolve_log_root,
+)
 
 
 def resolve_memory_root() -> Path:
@@ -96,12 +101,64 @@ def _pick_pose_for_time(location_rows: List[Dict[str, Any]], t_ms: int) -> Dict[
     }
 
 
+def _collision_to_unix_ms(collision_row: Dict[str, Any]) -> int:
+    t_ros = collision_row.get("t_ros", {})
+    secs = int(t_ros.get("secs", 0))
+    nsecs = int(t_ros.get("nsecs", 0))
+    return int(secs * 1000 + nsecs / 1_000_000)
+
+
+def _pick_collision_events_for_time(
+    collision_rows: List[Dict[str, Any]],
+    t_ms: int,
+    *,
+    turtle_id: str,
+    window_ms: int = 1500,
+    max_events: int = 3,
+) -> List[Dict[str, Any]]:
+    candidates: List[Tuple[int, Dict[str, Any]]] = []
+    for row in collision_rows:
+        turtles = row.get("turtles", [])
+        if isinstance(turtles, list) and turtles and turtle_id not in turtles:
+            continue
+        event_t_ms = _collision_to_unix_ms(row)
+        delta = abs(event_t_ms - t_ms)
+        if delta > window_ms:
+            continue
+        candidates.append((delta, row))
+
+    if not candidates:
+        return []
+
+    candidates.sort(key=lambda item: item[0])
+    out: List[Dict[str, Any]] = []
+    for delta, row in candidates[:max_events]:
+        out.append(
+            {
+                "type": "collision",
+                "event_type": str(row.get("event_type", "unknown")),
+                "collision_type": str(row.get("collision_type", "unknown")),
+                "obstacle_id": row.get("obstacle_id"),
+                "turtles": row.get("turtles", []),
+                "t_ms": _collision_to_unix_ms(row),
+                "distance_ms": delta,
+                "pose": {
+                    "x": float(row.get("x", 0.0)),
+                    "y": float(row.get("y", 0.0)),
+                    "theta": float(row.get("theta", 0.0)),
+                },
+            }
+        )
+    return out
+
+
 class MemoryConverter:
     """거북이 로그를 단기/장기 기억 스키마로 변환해 저장합니다."""
 
     def __init__(self, memory_root: Optional[Path] = None) -> None:
         """변환기 인스턴스를 초기화합니다."""
         self._memory_root = memory_root or resolve_memory_root()
+        self._default_collision_window_ms = 1500
     def convert_session(
         self,
         *,
@@ -111,6 +168,7 @@ class MemoryConverter:
         test_case_id: Optional[str] = None,
         log_root: Optional[Path] = None,
         write_long_term: bool = False,
+        collision_window_ms: Optional[int] = None,
     ) -> Dict[str, int]:
         """세션 로그를 읽어 단기 기억 파일로 변환 저장합니다."""
         log_root = log_root or resolve_log_root()
@@ -135,14 +193,26 @@ class MemoryConverter:
         if not resolved_session or not resolved_turtle:
             raise ValueError("session_id와 turtle_id를 확인할 수 없습니다.")
 
+        collision_path = build_collision_log_path(
+            log_root=log_root,
+            date_str=date_str,
+            session_id=resolved_session,
+        )
         location_rows = read_jsonl(location_path)
         command_rows = read_jsonl(command_path)
+        collision_rows = read_jsonl(collision_path)
         command_rows = normalize_command_rows(command_rows)
         short_term_records = self._build_short_term_records(
             location_rows=location_rows,
             command_rows=command_rows,
+            collision_rows=collision_rows,
             session_id=resolved_session,
             turtle_id=resolved_turtle,
+            collision_window_ms=(
+                self._default_collision_window_ms
+                if collision_window_ms is None
+                else max(0, int(collision_window_ms))
+            ),
         )
 
         resolved_test_case_id = test_case_id or resolved_session
@@ -184,8 +254,10 @@ class MemoryConverter:
         *,
         location_rows: List[Dict[str, Any]],
         command_rows: List[Dict[str, Any]],
+        collision_rows: List[Dict[str, Any]],
         session_id: str,
         turtle_id: str,
+        collision_window_ms: int,
     ) -> List[Dict[str, Any]]:
         intents = [row for row in command_rows if row.get("type") == "intent"]
         skills = [row for row in command_rows if row.get("type") == "skill"]
@@ -220,7 +292,12 @@ class MemoryConverter:
                                 "result": s.get("result", ""),
                             }
                         ],
-                        "events": [],
+                        "events": _pick_collision_events_for_time(
+                            collision_rows,
+                            step_t_ms,
+                            turtle_id=turtle_id,
+                            window_ms=collision_window_ms,
+                        ),
                     }
                 )
 
@@ -291,11 +368,23 @@ class MemoryConverter:
             if str(short.get("active_goal", {}).get("natural_language", "")).strip()
         ]
         action_trace: List[Dict[str, Any]] = []
+        short_term_collision_events = 0
+        short_term_collision_enter_count = 0
+        collision_obstacles = set()
         for short in short_term_batch:
             steps = short.get("execution_trace", {}).get("steps", [])
             if not steps:
                 continue
             step = steps[-1]
+            for event in step.get("events", []):
+                if str(event.get("type", "")) != "collision":
+                    continue
+                short_term_collision_events += 1
+                if str(event.get("event_type", "")) == "enter":
+                    short_term_collision_enter_count += 1
+                obstacle_id = event.get("obstacle_id")
+                if isinstance(obstacle_id, str) and obstacle_id:
+                    collision_obstacles.add(obstacle_id)
             invocations = step.get("skill_invocations", [])
             if not invocations:
                 continue
@@ -356,6 +445,9 @@ class MemoryConverter:
                         sum(1 for item in action_trace if item.get("status") == "success") / max(1, len(action_trace)),
                         3,
                     ),
+                    "collision_events": short_term_collision_events,
+                    "collision_enter_count": short_term_collision_enter_count,
+                    "collision_obstacles": sorted(collision_obstacles),
                 },
                 "lessons": [
                     "Follow-up references should inherit prior shape context.",

--- a/tests/test_turtle_agent/test_memory_converter.py
+++ b/tests/test_turtle_agent/test_memory_converter.py
@@ -14,7 +14,7 @@ from memory_converter import (  # noqa: E402
     build_short_term_path,
     parse_context_from_log_path,
 )
-from pose_logger import build_location_log_path  # noqa: E402
+from pose_logger import build_collision_log_path, build_location_log_path  # noqa: E402
 from command_logger import build_command_log_path  # noqa: E402
 
 
@@ -39,6 +39,7 @@ class TestMemoryConverter(unittest.TestCase):
 
         location_path = build_location_log_path(log_root, date_str, session_id, turtle_id)
         command_path = build_command_log_path(log_root, date_str, session_id, turtle_id)
+        collision_path = build_collision_log_path(log_root, date_str, session_id)
         location_path.parent.mkdir(parents=True, exist_ok=True)
 
         # 실제 장애물 월드 실행에서 수집한 location 로그 패턴을 반영한 샘플
@@ -102,6 +103,48 @@ class TestMemoryConverter(unittest.TestCase):
             encoding="utf-8",
         )
         command_path.write_text(json.dumps(command_doc, ensure_ascii=False) + "\n", encoding="utf-8")
+        collision_rows = [
+            {
+                "event_type": "enter",
+                "collision_type": "turtle_obstacle",
+                "turtles": [turtle_id],
+                "obstacle_id": "wet",
+                "t_ros": {"secs": 1777265125, "nsecs": 250000000},
+                "x": 10.88,
+                "y": 5.54,
+                "theta": 0.0,
+                "linear_velocity": 0.55,
+                "angular_velocity": 0.0,
+            },
+            {
+                "event_type": "enter",
+                "collision_type": "turtle_obstacle",
+                "turtles": ["turtle2"],
+                "obstacle_id": "wet-other",
+                "t_ros": {"secs": 1777265125, "nsecs": 495000000},
+                "x": 10.90,
+                "y": 5.54,
+                "theta": 0.0,
+                "linear_velocity": 0.55,
+                "angular_velocity": 0.0,
+            },
+            {
+                "event_type": "stay",
+                "collision_type": "turtle_obstacle",
+                "turtles": [turtle_id],
+                "obstacle_id": "wet-far",
+                "t_ros": {"secs": 1777265124, "nsecs": 100000000},
+                "x": 10.20,
+                "y": 5.54,
+                "theta": 0.0,
+                "linear_velocity": 0.55,
+                "angular_velocity": 0.0,
+            }
+        ]
+        collision_path.write_text(
+            "\n".join(json.dumps(r, ensure_ascii=False) for r in collision_rows) + "\n",
+            encoding="utf-8",
+        )
 
         converter = MemoryConverter(memory_root=memory_root)
         long_path = build_long_term_path(memory_root, session_id)
@@ -114,6 +157,7 @@ class TestMemoryConverter(unittest.TestCase):
             turtle_id=turtle_id,
             test_case_id=test_case_id,
             log_root=log_root,
+            collision_window_ms=300,
         )
 
         self.assertEqual(result["short_term_written"], 2)
@@ -132,6 +176,13 @@ class TestMemoryConverter(unittest.TestCase):
         self.assertEqual(short_rows[0]["active_goal"]["natural_language"], obstacle_run_cmd)
         self.assertNotIn("intent_norm", short_rows[0])
         self.assertEqual(short_rows[1]["plan"]["current_step_idx"], 2)
+        self.assertEqual(short_rows[0]["execution_trace"]["steps"][-1]["events"], [])
+        second_events = short_rows[1]["execution_trace"]["steps"][-1]["events"]
+        self.assertEqual(len(second_events), 1)
+        self.assertEqual(second_events[0]["type"], "collision")
+        self.assertEqual(second_events[0]["event_type"], "enter")
+        self.assertEqual(second_events[0]["collision_type"], "turtle_obstacle")
+        self.assertEqual(second_events[0]["obstacle_id"], "wet")
         self.assertEqual(len(long_rows), before_long_count)
 
     def test_finalize_session_writes_compressed_long_term(self):
@@ -166,6 +217,19 @@ class TestMemoryConverter(unittest.TestCase):
         }
         for idx in range(5):
             rec = dict(base)
+            step = dict(base["execution_trace"]["steps"][0])
+            step["events"] = [
+                {
+                    "type": "collision",
+                    "event_type": "enter",
+                    "collision_type": "turtle_obstacle",
+                    "obstacle_id": "wet",
+                    "t_ms": 1777275300520 + idx,
+                    "distance_ms": idx,
+                    "pose": {"x": 5.5, "y": 5.5, "theta": 1.2},
+                }
+            ]
+            rec["execution_trace"] = {"steps": [step]}
             rec["clock"] = {"unix_ms": 1777275300520 + idx, "map_id": "world"}
             path = session_dir / f"short_testid_tc-{idx}.jsonl"
             path.write_text(json.dumps(rec, ensure_ascii=False) + "\n", encoding="utf-8")
@@ -181,6 +245,12 @@ class TestMemoryConverter(unittest.TestCase):
         self.assertEqual(rows[-1]["record_type"], "compressed_routine")
         self.assertEqual(rows[-1]["turtle_id"], turtle_id)
         self.assertEqual(rows[-1]["payload"]["evidence"]["n_episodes"], 5)
+        self.assertIn("success_rate", rows[-1]["payload"]["evidence"])
+        self.assertEqual(rows[-1]["payload"]["evidence"]["collision_events"], 5)
+        self.assertEqual(rows[-1]["payload"]["evidence"]["collision_enter_count"], 5)
+        self.assertEqual(rows[-1]["payload"]["evidence"]["collision_obstacles"], ["wet"])
+        self.assertIn("routine", rows[-1]["payload"])
+        self.assertIn("meta", rows[-1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 연관 이슈
- Refs #16

## 변경 내용
- collision 로그를 short-term/long-term 메모리 변환 파이프라인의 증거 데이터로 연결했습니다.
- 메모리 변환 시 충돌 이벤트를 실행 이력과 함께 저장해, 후속 정책 생성/재사용 시 충돌 맥락을 활용할 수 있게 했습니다.
- 기존 메모리 스키마 흐름과의 호환을 유지하면서 충돌 근거 필드를 확장했습니다.

## 테스트
- [x] 로컬 실행 테스트 완료
- [x] 회귀 영향 확인

## 영향 범위
- `turtle_agent`의 로그→메모리 변환 경로(`memory_converter`, collision 로그 소비 경로)에 영향이 있습니다.
- 기존 세션/메모리 파일을 읽는 흐름은 유지되나, 충돌 근거 필드가 추가되어 출력 데이터 양이 증가할 수 있습니다.