### PR TITLE
refactor: 장애물 kind ephemeral를 temporary로 통일

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ JSON map such as `src/turtle_agent/config/static_obstacles_turtlesim.yaml`.
 When `~draw_static_world` is enabled, a startup-only `rospy` world builder reads
 the same store snapshot and draws the static world with a temporary builder
 turtle. Runtime obstacle CRUD is managed through LangChain tools that update the
-same store directly. `static` obstacles remain until removed; `ephemeral`
+same store directly. `static` obstacles remain until removed; `temporary`
 obstacles expire after their TTL. No HTTP layer is used for obstacle CRUD or
 initial map injection.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -152,4 +152,4 @@ The following test categories are included in our testing setup. Further details
 - **Obstacle Policy:**
   - Static maps are loaded into the in-process `ObstacleStore`.
   - Initial world drawing is performed by a startup `rospy` builder, not by the LLM or LangChain tools.
-  - Runtime obstacle CRUD updates the same store through tools. `static` obstacles remain until removed, and `ephemeral` obstacles expire after their TTL. No HTTP API is used.
+  - Runtime obstacle CRUD updates the same store through tools. `static` obstacles remain until removed, and `temporary` obstacles expire after their TTL. No HTTP API is used.

--- a/src/turtle_agent/config/static_obstacles_turtlesim.yaml
+++ b/src/turtle_agent/config/static_obstacles_turtlesim.yaml
@@ -25,9 +25,9 @@ obstacles:
       type: segments
       segments:
         - [ [ 0.0, 11.0 ], [ 0.0, 0.0 ] ]
-  # Wet markers: side-1 squares; kind ephemeral (optional ttl_seconds; else loader default).
+  # Wet markers: side-1 squares; kind temporary (optional ttl_seconds; else loader default).
   - id: wet-top
-    kind: ephemeral
+    kind: temporary
     geometry:
       type: aabb
       min_x: 4.5
@@ -35,7 +35,7 @@ obstacles:
       max_x: 5.5
       max_y: 9.5
   - id: wet-right
-    kind: ephemeral
+    kind: temporary
     geometry:
       type: aabb
       min_x: 8.5
@@ -43,7 +43,7 @@ obstacles:
       max_x: 9.5
       max_y: 5.5
   - id: wet-bottom
-    kind: ephemeral
+    kind: temporary
     geometry:
       type: aabb
       min_x: 4.5

--- a/src/turtle_agent/scripts/obstacle_store.py
+++ b/src/turtle_agent/scripts/obstacle_store.py
@@ -26,9 +26,10 @@ Each :class:`Obstacle` is immutable. Geometry variants align with
 
 ``ObstacleStore`` uses :class:`threading.RLock`. :meth:`snapshot` returns a tuple
 of obstacles consistent with a single lock acquisition (after purging expired
-``ephemeral`` entries), suitable for one collision-evaluation pass.
+``temporary`` entries), suitable for one collision-evaluation pass.
 
-Ephemeral TTL uses :func:`time.monotonic` deadlines in :attr:`Obstacle.expires_at`.
+Temporary-obstacle TTL uses :func:`time.monotonic` deadlines in
+:attr:`Obstacle.expires_at`.
 """
 
 from __future__ import annotations
@@ -40,7 +41,7 @@ from typing import Dict, Literal, Optional, Tuple, Union
 
 from collision_geometry import Segment
 
-ObstacleKind = Literal["static", "ephemeral", "turtle"]
+ObstacleKind = Literal["static", "temporary", "turtle"]
 
 
 @dataclass(frozen=True)
@@ -92,13 +93,13 @@ def _normalize_geometry(geometry: ObstacleGeometry) -> ObstacleGeometry:
 
 
 def _validate_obstacle(obstacle: Obstacle) -> None:
-    if obstacle.kind == "ephemeral":
+    if obstacle.kind == "temporary":
         if obstacle.expires_at is None:
             raise ValueError(
-                "ephemeral obstacles require expires_at (monotonic deadline)"
+                "temporary obstacles require expires_at (monotonic deadline)"
             )
     elif obstacle.expires_at is not None:
-        raise ValueError("only ephemeral obstacles may set expires_at")
+        raise ValueError("only temporary obstacles may set expires_at")
 
 
 def _copy_obstacle_for_snapshot(obstacle: Obstacle) -> Obstacle:
@@ -115,7 +116,7 @@ def _copy_obstacle_for_snapshot(obstacle: Obstacle) -> Obstacle:
 
 
 class ObstacleStore:
-    """Thread-safe store: upsert/remove/get/snapshot with ephemeral expiry."""
+    """Thread-safe store: upsert/remove/get/snapshot with temporary-obstacle expiry."""
 
     def __init__(self) -> None:
         self._lock = threading.RLock()

--- a/src/turtle_agent/scripts/static_map_loader.py
+++ b/src/turtle_agent/scripts/static_map_loader.py
@@ -27,8 +27,8 @@ YAML/JSON document shape::
 Field mapping (file keys → :mod:`obstacle_store` types):
 
 - ``id`` (str, required) → :attr:`Obstacle.id`
-- ``kind``: ``\"static\"`` (default) or ``\"ephemeral\"``. Ephemeral deadlines use
-  ``ttl_seconds`` if given, else :data:`DEFAULT_EPHEMERAL_TTL_SECONDS` at load time.
+- ``kind``: ``\"static\"`` (default) or ``\"temporary\"``. Temporary deadlines use
+  ``ttl_seconds`` if given, else :data:`DEFAULT_TEMPORARY_TTL_SECONDS` at load time.
 - ``geometry.type``:
 
   - ``circle`` — keys ``cx``, ``cy``, ``r`` (numbers) → :class:`CircleGeometry`
@@ -74,8 +74,8 @@ from obstacle_store import (
 
 OnDuplicateId = Literal["replace", "error"]
 
-# Used when ``kind: ephemeral`` and ``ttl_seconds`` is omitted (seconds).
-DEFAULT_EPHEMERAL_TTL_SECONDS = 31_536_000.0
+# Used when ``kind: temporary`` and ``ttl_seconds`` is omitted (seconds).
+DEFAULT_TEMPORARY_TTL_SECONDS = 31_536_000.0
 
 
 class StaticMapLoadError(ValueError):
@@ -194,9 +194,9 @@ def _parse_obstacle_entry(raw: Any, *, source: Optional[str], index: int) -> Obs
     if not isinstance(kind, str):
         raise _err("kind must be a string", source=source, index=index)
     kind_l = kind.strip().lower()
-    if kind_l not in ("static", "ephemeral"):
+    if kind_l not in ("static", "temporary"):
         raise _err(
-            f"map kind must be 'static' or 'ephemeral', got {kind!r}",
+            f"map kind must be 'static' or 'temporary', got {kind!r}",
             source=source,
             index=index,
         )
@@ -210,17 +210,17 @@ def _parse_obstacle_entry(raw: Any, *, source: Optional[str], index: int) -> Obs
             geometry=geometry,
             expires_at=None,
         )
-    raw_ttl = raw.get("ttl_seconds", DEFAULT_EPHEMERAL_TTL_SECONDS)
+    raw_ttl = raw.get("ttl_seconds", DEFAULT_TEMPORARY_TTL_SECONDS)
     ttl = _coerce_float(raw_ttl, key="ttl_seconds", source=source, index=index)
     if ttl <= 0:
         raise _err(
-            "ttl_seconds must be positive for ephemeral obstacles",
+            "ttl_seconds must be positive for temporary obstacles",
             source=source,
             index=index,
         )
     return Obstacle(
         id=oid.strip(),
-        kind="ephemeral",
+        kind="temporary",
         geometry=geometry,
         expires_at=time.monotonic() + ttl,
     )

--- a/src/turtle_agent/scripts/tools/obstacle.py
+++ b/src/turtle_agent/scripts/tools/obstacle.py
@@ -152,21 +152,21 @@ def add_obstacle(
     ``{"type":"segments","segments":[[[0,0],[1,0]]]}``.
 
     ``kind`` is ``static`` for an obstacle that remains until removed, or
-    ``ephemeral`` for a temporary obstacle that expires after ``ttl_seconds``.
+    ``temporary`` for an obstacle that expires after ``ttl_seconds``.
     """
     try:
         oid = obstacle_id.strip()
         if not oid:
             raise ObstacleToolError("obstacle_id must be a non-empty string.")
         kind_l = kind.strip().lower()
-        if kind_l not in ("static", "ephemeral"):
-            raise ObstacleToolError("kind must be 'static' or 'ephemeral'.")
+        if kind_l not in ("static", "temporary"):
+            raise ObstacleToolError("kind must be 'static' or 'temporary'.")
         expires_at = None
-        if kind_l == "ephemeral":
+        if kind_l == "temporary":
             ttl = _coerce_float(ttl_seconds, "ttl_seconds")
             if ttl <= 0:
                 raise ObstacleToolError(
-                    "ttl_seconds must be positive for ephemeral obstacles."
+                    "ttl_seconds must be positive for temporary obstacles."
                 )
             expires_at = time.monotonic() + ttl
         geometry = _parse_geometry_json(geometry_json)
@@ -178,8 +178,8 @@ def add_obstacle(
                 expires_at=expires_at,
             )
         )
-        if kind_l == "ephemeral":
-            return f"Added ephemeral obstacle '{oid}' with ttl_seconds={ttl}."
+        if kind_l == "temporary":
+            return f"Added temporary obstacle '{oid}' with ttl_seconds={ttl}."
         return f"Added static obstacle '{oid}'."
     except (ObstacleToolError, ValueError) as e:
         return f"Failed to add obstacle: {e}"

--- a/tests/test_turtle_agent/test_collision_monitor.py
+++ b/tests/test_turtle_agent/test_collision_monitor.py
@@ -149,7 +149,7 @@ class TestCollisionMonitor(unittest.TestCase):
         store.upsert(
             Obstacle(
                 "temp",
-                "ephemeral",
+                "temporary",
                 CircleGeometry(0.0, 0.0, 1.0),
                 time.monotonic() + 0.05,
             )

--- a/tests/test_turtle_agent/test_obstacle_store.py
+++ b/tests/test_turtle_agent/test_obstacle_store.py
@@ -61,13 +61,13 @@ class TestObstacleStoreSingleThread(unittest.TestCase):
         store.clear()
         self.assertEqual(len(store), 0)
 
-    def test_ephemeral_expires_on_snapshot(self):
+    def test_temporary_expires_on_snapshot(self):
         store = ObstacleStore()
         deadline = time.monotonic() + 0.05
         store.upsert(
             Obstacle(
                 "e",
-                "ephemeral",
+                "temporary",
                 CircleGeometry(0.0, 0.0, 1.0),
                 deadline,
             )
@@ -75,11 +75,11 @@ class TestObstacleStoreSingleThread(unittest.TestCase):
         time.sleep(0.1)
         self.assertEqual(len(store.snapshot()), 0)
 
-    def test_ephemeral_expires_on_get(self):
+    def test_temporary_expires_on_get(self):
         store = ObstacleStore()
         deadline = time.monotonic() + 0.05
         store.upsert(
-            Obstacle("e", "ephemeral", CircleGeometry(0.0, 0.0, 1.0), deadline)
+            Obstacle("e", "temporary", CircleGeometry(0.0, 0.0, 1.0), deadline)
         )
         time.sleep(0.1)
         self.assertIsNone(store.get("e"))
@@ -89,7 +89,7 @@ class TestObstacleStoreSingleThread(unittest.TestCase):
         store.upsert(
             Obstacle(
                 "e",
-                "ephemeral",
+                "temporary",
                 CircleGeometry(0.0, 0.0, 1.0),
                 time.monotonic() - 1.0,
             )
@@ -97,10 +97,10 @@ class TestObstacleStoreSingleThread(unittest.TestCase):
         store.purge_expired()
         self.assertEqual(len(store), 0)
 
-    def test_validation_ephemeral_requires_deadline(self):
+    def test_validation_temporary_requires_deadline(self):
         with self.assertRaises(ValueError):
             ObstacleStore().upsert(
-                Obstacle("bad", "ephemeral", CircleGeometry(0.0, 0.0, 1.0), None)
+                Obstacle("bad", "temporary", CircleGeometry(0.0, 0.0, 1.0), None)
             )
 
     def test_validation_static_may_not_have_deadline(self):

--- a/tests/test_turtle_agent/test_obstacle_tools.py
+++ b/tests/test_turtle_agent/test_obstacle_tools.py
@@ -68,28 +68,28 @@ class TestObstacleTools(unittest.TestCase):
         self.assertIn("Failed to add obstacle", out)
         self.assertEqual(len(self.store), 0)
 
-    def test_add_ephemeral_rejects_non_positive_ttl(self):
+    def test_add_temporary_rejects_non_positive_ttl(self):
         out = obstacle_tools.add_obstacle.invoke(
             {
                 "obstacle_id": "bad",
                 "geometry_json": json.dumps(
                     {"type": "circle", "cx": 0, "cy": 0, "r": 1}
                 ),
-                "kind": "ephemeral",
+                "kind": "temporary",
                 "ttl_seconds": 0,
             }
         )
-        self.assertIn("ttl_seconds must be positive for ephemeral obstacles", out)
+        self.assertIn("ttl_seconds must be positive for temporary obstacles", out)
         self.assertEqual(len(self.store), 0)
 
-    def test_ephemeral_expires_from_tool_listing(self):
+    def test_temporary_expires_from_tool_listing(self):
         obstacle_tools.add_obstacle.invoke(
             {
                 "obstacle_id": "short",
                 "geometry_json": json.dumps(
                     {"type": "circle", "cx": 0, "cy": 0, "r": 1}
                 ),
-                "kind": "ephemeral",
+                "kind": "temporary",
                 "ttl_seconds": 0.01,
             }
         )

--- a/tests/test_turtle_agent/test_static_map_loader.py
+++ b/tests/test_turtle_agent/test_static_map_loader.py
@@ -203,7 +203,7 @@ class TestStaticMapLoader(unittest.TestCase):
         finally:
             Path(path).unlink(missing_ok=True)
 
-    def test_ephemeral_kind_without_ttl_uses_default(self):
+    def test_temporary_kind_without_ttl_uses_default(self):
         store = ObstacleStore()
         load_into_store(
             store,
@@ -211,7 +211,7 @@ class TestStaticMapLoader(unittest.TestCase):
                 "obstacles": [
                     {
                         "id": "e",
-                        "kind": "ephemeral",
+                        "kind": "temporary",
                         "geometry": {"type": "circle", "cx": 0.0, "cy": 0.0, "r": 0.1},
                     }
                 ]
@@ -219,10 +219,10 @@ class TestStaticMapLoader(unittest.TestCase):
         )
         o = store.get("e")
         assert o is not None
-        self.assertEqual(o.kind, "ephemeral")
+        self.assertEqual(o.kind, "temporary")
         self.assertIsNotNone(o.expires_at)
 
-    def test_ephemeral_explicit_ttl_seconds(self):
+    def test_temporary_explicit_ttl_seconds(self):
         import time as _time
 
         store = ObstacleStore()
@@ -233,7 +233,7 @@ class TestStaticMapLoader(unittest.TestCase):
                 "obstacles": [
                     {
                         "id": "e",
-                        "kind": "ephemeral",
+                        "kind": "temporary",
                         "ttl_seconds": 30.0,
                         "geometry": {"type": "circle", "cx": 0, "cy": 0, "r": 0.1},
                     }
@@ -270,7 +270,7 @@ class TestStaticMapLoader(unittest.TestCase):
         )
         wet = store.get("wet-top")
         assert wet is not None
-        self.assertEqual(wet.kind, "ephemeral")
+        self.assertEqual(wet.kind, "temporary")
         self.assertIsNotNone(wet.expires_at)
 
 


### PR DESCRIPTION
## 변경 내용

- 장애물 종류 문자열 `ephemeral`을 **`temporary`**로 통일했습니다. 동작(TTL·`expires_at`·스토어 정리)은 동일하고 공개되는 `kind` 값과 메시지만 바뀝니다.
- 적용 위치: `ObstacleKind`, 정적 맵 로더·샘플 YAML, 장애물 툴, README/TESTING, 관련 단위 테스트.

## 관련 이슈

- Closes #36

## 테스트

- [x] `uv run python -m unittest tests.test_turtle_agent.test_obstacle_store tests.test_turtle_agent.test_static_map_loader tests.test_turtle_agent.test_obstacle_tools tests.test_turtle_agent.test_collision_monitor -v`

## 호환

- 기존 맵/로그에 `ephemeral`이 남아 있으면 로더·파서를 업데이트해야 합니다(breaking).
