### PR TITLE
etc: Docker 개발환경과 EOL 정책을 정리

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+* text=auto
+
+# ROS/Python execution files must use LF on all OSes.
+*.py text eol=lf
+*.sh text eol=lf
+*.bash text eol=lf
+*.zsh text eol=lf
+*.launch text eol=lf
+
+# Keep Windows script compatibility where needed.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ __pycache__/
 .env
 logs/
 .specstory
+.catkin_tools/
+.devcontainer/
+devel/
+src/turtle_agent/scripts/memory/**/*.jsonl

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,15 @@ RUN apt-get update && apt-get install -y \
     python3.9 \
     python3-pip \
     curl \
-    build-essential
+    build-essential \
+    openssh-server
+
+RUN mkdir /var/run/sshd && \
+    echo 'root:ros' | chpasswd && \
+    sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
+    sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config
+
+EXPOSE 22
 
 # Install Rust (required for building tiktoken)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -43,7 +51,8 @@ RUN /bin/bash -c 'if [ "$DEVELOPMENT" = "true" ]; then \
     python3.9 -m pip install --break-system-packages --ignore-installed -U jpl-rosa>=1.0.8; \
     fi'
 
-CMD ["/bin/bash", "-c", "source /opt/ros/noetic/setup.bash && \
+CMD ["/bin/bash", "-c", "/usr/sbin/sshd && \
+    source /opt/ros/noetic/setup.bash && \
     roscore > /dev/null 2>&1 & \
     sleep 5 && \
     if [ \"$HEADLESS\" = \"false\" ]; then \


### PR DESCRIPTION
## 연관 이슈
- Refs #39

## 변경 내용
- Docker 컨테이너에 SSH 실행 경로를 추가하고 관련 설정(`openssh-server`, `sshd`)을 반영했습니다.
- 로컬 생성물(`.catkin_tools`, `.devcontainer`, `devel`, 메모리 jsonl`)이 추적되지 않도록 `.gitignore`를 정리했습니다.
- `.gitattributes`를 추가해 혼합 OS 환경에서 실행 영향이 큰 파일(`*.py`, `*.sh`, `*.launch`)의 EOL을 LF로 고정했습니다.

## 테스트
- [x] `source /opt/ros/noetic/setup.bash && source devel/setup.bash`
- [x] `roslaunch --files turtle_agent agent.launch` 경로 해석 확인
- [x] `roslaunch turtle_agent agent.launch` 실행 시 `python3.9\r` 오류 재발하지 않음