### PR TITLE
fix: 선분 그리기 중간 정지/언더슈팅 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ src/jpl_rosa.egg-info
 build/
 dist/
 __pycache__/
+.venv/
 .DS_Store
 .env
 logs/

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ src/jpl_rosa.egg-info
 build/
 dist/
 __pycache__/
-.venv/
 .DS_Store
 .env
 logs/

--- a/src/turtle_agent/scripts/tools/turtle.py
+++ b/src/turtle_agent/scripts/tools/turtle.py
@@ -321,19 +321,28 @@ def publish_twist_to_cmd_vel(
         global cmd_vel_pubs
         pub = cmd_vel_pubs[name]
 
-        for _ in range(steps):
+        # Publish continuously during each second-step to avoid undershooting.
+        publish_hz = 20
+        duration_sec = max(1.0, float(steps))
+        tick_count = max(1, int(duration_sec * publish_hz))
+        rate = rospy.Rate(publish_hz)
+        for _ in range(tick_count):
             pub.publish(vel)
-            rospy.sleep(1)
+            rate.sleep()
+
+        # Explicitly send a stop command so the turtle does not coast.
+        stop = Twist()
+        pub.publish(stop)
     except Exception as e:
         return f"Failed to publish {vel} to /{name}/cmd_vel: {e}"
-    finally:
-        current_pose = get_turtle_pose.invoke({"names": [name]})
-        return (
-            f"New Pose ({name}): x={current_pose[name].x}, y={current_pose[name].y}, "
-            f"theta={current_pose[name].theta} rads, "
-            f"linear_velocity={current_pose[name].linear_velocity}, "
-            f"angular_velocity={current_pose[name].angular_velocity}."
-        )
+
+    current_pose = get_turtle_pose.invoke({"names": [name]})
+    return (
+        f"New Pose ({name}): x={current_pose[name].x}, y={current_pose[name].y}, "
+        f"theta={current_pose[name].theta} rads, "
+        f"linear_velocity={current_pose[name].linear_velocity}, "
+        f"angular_velocity={current_pose[name].angular_velocity}."
+    )
 
 
 @tool
@@ -343,14 +352,21 @@ def stop_turtle(name: str):
 
     :param name: name of the turtle
     """
-    return publish_twist_to_cmd_vel.invoke(
-        {
-            "name": name,
-            "velocity": 0.0,
-            "lateral": 0.0,
-            "angle": 0.0,
-        }
-    )
+    name = name.replace("/", "")
+    try:
+        global cmd_vel_pubs
+        pub = cmd_vel_pubs[name]
+        stop = Twist()
+        for _ in range(3):
+            pub.publish(stop)
+            rospy.sleep(0.05)
+        current_pose = get_turtle_pose.invoke({"names": [name]})
+        return (
+            f"Stopped {name} at x={current_pose[name].x}, y={current_pose[name].y}, "
+            f"theta={current_pose[name].theta}."
+        )
+    except Exception as e:
+        return f"Failed to stop {name}: {e}"
 
 
 @tool
@@ -481,16 +497,51 @@ def draw_line_segment(name: str, x1: float, y1: float, x2: float, y2: float) -> 
     # Turn on pen
     set_pen.invoke({"name": name, "r": 0, "g": 0, "b": 0, "width": 2, "off": 0})
     
-    # Draw the line (angle=0 because heading is already set)
-    result = publish_twist_to_cmd_vel.invoke({
-        "name": name,
-        "velocity": distance,
-        "lateral": 0,
-        "angle": 0,
-        "steps": 1
-    })
-    
-    return f"Line drawn from ({x1},{y1}) to ({x2},{y2}). {result}"
+    # Draw in small chunks to avoid undershoot from one-shot long moves.
+    chunk_distance = 1.0
+    max_iterations = max(1, int(distance / chunk_distance) + 8)
+    last_result = ""
+    prev_remaining = None
+    for _ in range(max_iterations):
+        current_pose = get_turtle_pose.invoke({"names": [name]})
+        cx = float(current_pose[name].x)
+        cy = float(current_pose[name].y)
+        remaining = sqrt((x2 - cx) ** 2 + (y2 - cy) ** 2)
+        if remaining <= 0.2:
+            break
+
+        step = min(chunk_distance, remaining)
+        last_result = publish_twist_to_cmd_vel.invoke(
+            {
+                "name": name,
+                "velocity": step,
+                "lateral": 0,
+                "angle": 0,
+                "steps": 1,
+            }
+        )
+
+        # Abort if progress stalls to avoid infinite loops.
+        if prev_remaining is not None and remaining >= prev_remaining - 0.01:
+            break
+        prev_remaining = remaining
+
+    # Verify endpoint so interrupted/short moves are surfaced to the caller.
+    final_pose = get_turtle_pose.invoke({"names": [name]})
+    final_x = float(final_pose[name].x)
+    final_y = float(final_pose[name].y)
+    endpoint_error = sqrt((final_x - x2) ** 2 + (final_y - y2) ** 2)
+    if endpoint_error > 0.2:
+        return (
+            f"Line move incomplete from ({x1},{y1}) to ({x2},{y2}). "
+            f"Current pose=({final_x:.3f},{final_y:.3f}), error={endpoint_error:.3f}. "
+            f"Last move: {last_result}"
+        )
+
+    return (
+        f"Line drawn from ({x1},{y1}) to ({x2},{y2}). "
+        f"Final pose=({final_x:.3f},{final_y:.3f}), error={endpoint_error:.3f}."
+    )
 
 
 @tool


### PR DESCRIPTION
﻿## Summary
- publish_twist_to_cmd_vel를 연속 publish(20Hz) + 명시적 정지 publish 방식으로 바꿔 긴 선분 이동 중 언더슈팅을 줄였습니다.
- stop_turtle를 재귀 호출 대신 직접 정지 Twist publish 방식으로 변경해 정지 안정성을 높였습니다.
- draw_line_segment에 청크 기반 이동과 종점 오차 검증을 추가해, 불완전 이동 시 incomplete/error 정보를 명확히 노출하도록 했습니다.

## Related issue
- Closes #41

## Test plan
- [x] draw_line_segment('turtle1', 2, 2, 9, 2) 반복 실행 시 종점 도달률 개선 확인
- [x] 종점 미도달 상황에서 Line move incomplete ... error=... 메시지 노출 확인
- [x] 기본 도형 도구(draw_rectangle, draw_polyline) 회귀 수동 확인
