### PR TITLE
chore: 실행 환경 안정화 및 개발 편의 개선

### DIFF
--- a/run-agent-en.sh
+++ b/run-agent-en.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STREAMING="${1:-true}"
+# Git Bash에서는 docker -v에 Windows 경로를 넘겨야 마운트가 안정적입니다.
+if WORKSPACE_WIN="$(pwd -W 2>/dev/null)"; then
+  WORKSPACE="${WORKSPACE_WIN}"
+else
+  WORKSPACE="$(pwd)"
+fi
+
+docker run -it --rm \
+  --env-file .env \
+  -e TERM=xterm-256color \
+  -e ROSA_NO_CLEAR=1 \
+  -e DISPLAY=host.docker.internal:0 \
+  -v "${WORKSPACE}/src:/app/src" \
+  rosa bash -lc "
+set -e
+cd /app
+export PYTHONPATH=/app/src/turtle_agent/scripts:/app/src:\$PYTHONPATH
+sed -i 's/\r$//' /app/src/turtle_agent/scripts/turtle_agent.py
+echo '[VERIFY] tools.turtle=/app/src/turtle_agent/scripts/tools/turtle.py'
+if grep -q 'Final pose=' /app/src/turtle_agent/scripts/tools/turtle.py; then
+  echo '[VERIFY] patched_marker=True'
+else
+  echo '[VERIFY] patched_marker=False'
+fi
+catkin build
+source devel/setup.bash
+rosrun turtlesim turtlesim_node >/tmp/turtlesim.log 2>&1 &
+sleep 2
+if ! command -v rlwrap >/dev/null 2>&1; then
+  apt-get update >/tmp/apt-update.log 2>&1 || true
+  apt-get install -y rlwrap >/tmp/apt-install-rlwrap.log 2>&1 || true
+fi
+
+if command -v rlwrap >/dev/null 2>&1; then
+  rlwrap -cAr roslaunch /app/src/turtle_agent/launch/agent.launch streaming:=${STREAMING}
+else
+  echo "[WARN] rlwrap unavailable; arrow-key editing may still be broken."
+  roslaunch /app/src/turtle_agent/launch/agent.launch streaming:=${STREAMING}
+fi
+"

--- a/src/turtle_agent/scripts/turtle_agent.py
+++ b/src/turtle_agent/scripts/turtle_agent.py
@@ -260,6 +260,9 @@ class TurtleAgent(ROSA):
         self.clear_chat()
         self.last_events = []
         self.command_handler.pop("info", None)
+        no_clear = os.environ.get("ROSA_NO_CLEAR", "").strip().lower()
+        if no_clear in ("1", "true", "yes", "on"):
+            return
         os.system("clear")
 
     def get_input(self, prompt: str):
@@ -559,6 +562,7 @@ def main(
 if __name__ == "__main__":
     _maybe_attach_debugpy()
     rospy.init_node("rosa", log_level=rospy.INFO)
+    rospy.loginfo("runtime tools.turtle module: %s", getattr(turtle_tools, "__file__", "unknown"))
 
     # rospy.AsyncSpinner is missing in some stacks; a daemon spin thread is portable.
     def _ros_spin() -> None:


### PR DESCRIPTION
﻿## Summary
- 실행 시 화면 전체 clear를 끌 수 있도록 ROSA_NO_CLEAR 환경변수 옵션을 추가했습니다.
- 런타임에서 실제 로드된 	ools.turtle 모듈 경로를 시작 로그에 출력하도록 해, 소스 반영 여부를 즉시 확인할 수 있게 했습니다.
- Git Bash 전용 실행 스크립트 un-agent-en.sh를 추가/정비해 환경 변수, 경로 마운트, 실행 검증(VERIFY) 과정을 일관화했습니다.

## Related issue
- Closes #45

## Test plan
- [x] un-agent-en.sh 실행 시 VERIFY 로그 출력 확인
- [x] ROSA_NO_CLEAR=1 상태에서 화면 초기화 비활성화 확인
- [x] 노드 시작 시 runtime tools module 경로 로그 출력 확인
