### PR TITLE
chore: ignore local .venv directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ logs/
 .devcontainer/
 devel/
 src/turtle_agent/scripts/memory/**/*.jsonl
+.venv/


### PR DESCRIPTION
﻿## Summary
- .gitignore에 .venv/를 추가해 로컬 가상환경 파일이 변경 목록에 노이즈로 잡히지 않도록 정리했습니다.

## Test plan
- [x] git status에서 .venv/ 미추적 항목이 사라지는지 확인

연관 이슈 #45 
