### PR TITLE
feat: long-term retrieval top-k 선택 로직 개선

### DIFF
--- a/src/turtle_agent/scripts/memory_prompting.py
+++ b/src/turtle_agent/scripts/memory_prompting.py
@@ -29,6 +29,9 @@ def infer_query_context(query: str) -> Dict[str, Any]:
         slots["to"] = m_ko.group(2).upper()
 
     task_family = "natural_language_query"
+    # NOTE: 현재 retrieval 품질 검증 범위가 navigation 중심이라 navigate 분기를 명시적으로 유지한다.
+    # intent_norm(task_family=navigate, from/to slots)과 키를 맞춰 recall 일관성을 확보하는 목적이며,
+    # 추후 trace_shape/rotate 확장 시에는 task별 parser/score 전략을 분리할 계획이다.
     # 좌표 기반 이동/선분 (memory 매칭을 navigate와 맞춤 — long intent_norm 과 일치시키기 위함)
     if re.search(
         r"\b(?:draw\s+(?:a\s+)?line|line)\s+to\s+(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)",
@@ -168,9 +171,11 @@ def _score_record(query_ctx: Dict[str, Any], record_ctx: Dict[str, Any], quality
         score += 20
     if q_slots.get("to") and str(r_slots.get("to", "")).upper() == q_slots.get("to"):
         score += 20
-    if quality == "high":
+    # NOTE: 피드백에 따라 "성공 사례 우선" 대신 "실패 사례 우선" retrieval 정책을 적용한다.
+    # 당장은 task-agnostic 규칙으로 일반화하지 않고, navigation 실효성 검증을 우선한다.
+    if quality == "low":
         score += 8
-    elif quality == "low":
+    elif quality == "high":
         score -= 8
     return score
 
@@ -188,7 +193,8 @@ def _record_sort_tuple(score: int, record_ctx: Dict[str, Any], row: Dict[str, An
     success_rate = _safe_float(evidence.get("success_rate")) or 0.0
     collisions = _safe_int(evidence.get("collision_enter_count"), 0)
     created_at = _safe_int(row.get("meta", {}).get("created_at_unix_ms"), 0)
-    return (score, _slot_specificity(record_ctx), -collisions, success_rate, created_at)
+    # 정렬 우선순위(내림차순): score > slot_specificity > 충돌 많음 > 성공률 낮음 > 최신성
+    return (score, _slot_specificity(record_ctx), collisions, -success_rate, created_at)
 
 
 def build_memory_context(query: str, records: List[Dict[str, Any]], top_k: int = 3) -> Tuple[str, int]:

--- a/src/turtle_agent/scripts/memory_prompting.py
+++ b/src/turtle_agent/scripts/memory_prompting.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -110,70 +111,145 @@ def _record_context(row: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def _score_record(query_ctx: Dict[str, Any], record_ctx: Dict[str, Any]) -> int:
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(number):
+        return None
+    return number
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _quality_band(row: Dict[str, Any]) -> str:
+    payload = row.get("payload", {})
+    evidence = payload.get("evidence", {})
+    outcome = payload.get("outcome", {})
+    success = bool(outcome.get("success", False))
+    success_rate = _safe_float(evidence.get("success_rate"))
+    collisions = _safe_int(evidence.get("collision_enter_count"), 0)
+    if success and (success_rate is None or success_rate >= 0.8) and collisions <= 1:
+        return "high"
+    if (not success) or collisions >= 3 or (success_rate is not None and success_rate < 0.4):
+        return "low"
+    return "mid"
+
+
+def _slot_specificity(record_ctx: Dict[str, Any]) -> int:
+    slots = record_ctx.get("slots", {})
+    has_from = bool(str(slots.get("from", "")).strip())
+    has_to = bool(str(slots.get("to", "")).strip())
+    return int(has_from) + int(has_to)
+
+
+def _is_intent_match(query_ctx: Dict[str, Any], record_ctx: Dict[str, Any]) -> bool:
+    task_family = str(query_ctx.get("task_family", "")).strip()
+    if not task_family:
+        return False
+    return task_family == str(record_ctx.get("task_family", "")).strip()
+
+
+def _score_record(query_ctx: Dict[str, Any], record_ctx: Dict[str, Any], quality: str) -> int:
     score = 0
     if query_ctx["experience_key"] and query_ctx["experience_key"] == record_ctx["experience_key"]:
-        score += 100
+        score += 35
     if query_ctx["task_family"] and query_ctx["task_family"] == record_ctx["task_family"]:
-        score += 30
+        score += 50
     q_slots = query_ctx.get("slots", {})
     r_slots = record_ctx.get("slots", {})
     if q_slots.get("from") and str(r_slots.get("from", "")).upper() == q_slots.get("from"):
-        score += 10
+        score += 20
     if q_slots.get("to") and str(r_slots.get("to", "")).upper() == q_slots.get("to"):
-        score += 10
+        score += 20
+    if quality == "high":
+        score += 8
+    elif quality == "low":
+        score -= 8
     return score
 
 
-def build_memory_context(query: str, records: List[Dict[str, Any]], top_k: int = 2) -> Tuple[str, int]:
+def _dedupe_key(record_ctx: Dict[str, Any]) -> str:
+    slots = record_ctx.get("slots", {})
+    from_slot = str(slots.get("from", "")).upper().strip()
+    to_slot = str(slots.get("to", "")).upper().strip()
+    return f"{record_ctx.get('task_family', '')}|from:{from_slot}|to:{to_slot}"
+
+
+def _record_sort_tuple(score: int, record_ctx: Dict[str, Any], row: Dict[str, Any]) -> Tuple[int, int, int, float, int]:
+    payload = row.get("payload", {})
+    evidence = payload.get("evidence", {})
+    success_rate = _safe_float(evidence.get("success_rate")) or 0.0
+    collisions = _safe_int(evidence.get("collision_enter_count"), 0)
+    created_at = _safe_int(row.get("meta", {}).get("created_at_unix_ms"), 0)
+    return (score, _slot_specificity(record_ctx), -collisions, success_rate, created_at)
+
+
+def build_memory_context(query: str, records: List[Dict[str, Any]], top_k: int = 3) -> Tuple[str, int]:
     query_ctx = infer_query_context(query)
-    ranked: List[Tuple[int, Dict[str, Any]]] = []
+    max_k = max(0, int(top_k))
+    if max_k == 0:
+        return "", 0
+    min_score = 45
+    deduped: Dict[str, Tuple[Tuple[int, int, int, float, int], Dict[str, Any], str, Dict[str, Any], int]] = {}
     for row in records:
         record_ctx = _record_context(row)
-        score = _score_record(query_ctx, record_ctx)
-        if score <= 0:
+        if not _is_intent_match(query_ctx, record_ctx):
             continue
-        ranked.append((score, row))
-    if not ranked:
+        quality = _quality_band(row)
+        score = _score_record(query_ctx, record_ctx, quality)
+        if score < min_score:
+            continue
+        sort_tuple = _record_sort_tuple(score, record_ctx, row)
+        key = _dedupe_key(record_ctx)
+        prev = deduped.get(key)
+        if prev is None or sort_tuple > prev[0]:
+            deduped[key] = (sort_tuple, row, quality, record_ctx, score)
+    if not deduped:
         return "", 0
-    ranked.sort(key=lambda item: item[0], reverse=True)
-    selected = [row for _, row in ranked[: max(1, int(top_k))]]
+    ranked = sorted(deduped.values(), key=lambda item: item[0], reverse=True)
+    selected = ranked[: min(max_k, len(ranked))]
     lines: List[str] = []
-    lesson_lines: List[str] = []
-    max_collision_enter = 0
-    for idx, row in enumerate(selected, start=1):
+    do_lines: List[str] = []
+    dont_lines: List[str] = []
+    for idx, (_, row, quality, _, score) in enumerate(selected, start=1):
         payload = row.get("payload", {})
         op = payload.get("operation", {})
         goal_text = str(op.get("nl_goal", {}).get("text", ""))
         evidence = payload.get("evidence", {})
-        collisions = int(evidence.get("collision_enter_count", 0))
-        max_collision_enter = max(max_collision_enter, collisions)
-        success_rate = evidence.get("success_rate")
+        collisions = _safe_int(evidence.get("collision_enter_count"), 0)
+        success_rate = _safe_float(evidence.get("success_rate"))
         lines.append(
-            f"{idx}. goal={goal_text[:160]} / collision_enter_count={collisions} / success_rate={success_rate}"
+            f"{idx}. score={score} quality={quality} goal={goal_text[:120]} / collision_enter_count={collisions} / success_rate={success_rate}"
         )
         raw_lessons = payload.get("lessons")
         if isinstance(raw_lessons, list):
-            for _, lesson in enumerate(raw_lessons):
+            for lesson in raw_lessons:
                 if isinstance(lesson, str) and lesson.strip():
-                    lesson_lines.append(f"[memory {idx}] {lesson.strip()}")
+                    if quality == "low":
+                        dont_lines.append(f"[memory {idx}] {lesson.strip()}")
+                    else:
+                        do_lines.append(f"[memory {idx}] {lesson.strip()}")
+    policy_lines = ["MUST: Use selected memory as execution policy, not commentary."]
+    if query_ctx.get("task_family") == "navigate":
+        policy_lines.append("MUST: Avoid single long straight moves when uncertainty exists.")
+    if dont_lines:
+        policy_lines.append("MUST: Treat DON'T items as forbidden patterns for this query.")
     policy_lines = [
-        "MUST: Use memory as executable policy for this query, not as optional commentary.",
-        "MUST: Prefer multi-step segmented movement over a single direct movement command.",
+        line for line in policy_lines if line.strip()
     ]
-    if query_ctx.get("task_family") == "navigate" and max_collision_enter > 0:
-        policy_lines.extend(
-            [
-                "MUST: Do not choose a single straight-line path for this navigation.",
-                "MUST: If a move attempt causes collision, immediately replan with smaller segmented moves.",
-            ]
-        )
-    context = (
-        "Memory policy (strict):\n"
-        + "\n".join(f"- {line}" for line in policy_lines)
-        + "\n\nMemory evidence:\n"
-        + "\n".join(lines)
-    )
-    if lesson_lines:
-        context += "\n\nMemory lessons:\n" + "\n".join(f"- {line}" for line in lesson_lines)
+    context = "Memory policy (strict):\n"
+    context += "\n".join(f"- {line}" for line in policy_lines)
+    context += "\n\nMemory evidence:\n"
+    context += "\n".join(lines)
+    if do_lines:
+        context += "\n\nDO rules:\n" + "\n".join(f"- {line}" for line in do_lines[:6])
+    if dont_lines:
+        context += "\n\nDON'T rules:\n" + "\n".join(f"- {line}" for line in dont_lines[:6])
     return context, len(selected)

--- a/src/turtle_agent/scripts/turtle_agent.py
+++ b/src/turtle_agent/scripts/turtle_agent.py
@@ -314,13 +314,17 @@ class TurtleAgent(ROSA):
 
     async def submit(self, query: str):
         query_ctx = infer_query_context(query)
-        long_records = load_long_term_records(self._memory_root, self._turtle_id)
-        memory_context, memory_hits = build_memory_context(query, long_records, top_k=2)
+        memory_context = ""
+        memory_hits = 0
+        if self._agent_mode.strip().lower() == "single":
+            long_records = load_long_term_records(self._memory_root, self._turtle_id)
+            memory_context, memory_hits = build_memory_context(query, long_records, top_k=3)
         effective_query = (
             f"{memory_context}\n\nUser query:\n{query}" if memory_context else query
         )
         rospy.loginfo(
-            "memory prompt: hits=%s experience_key=%s",
+            "memory prompt: mode=%s hits=%s experience_key=%s",
+            self._agent_mode,
             memory_hits,
             query_ctx.get("experience_key", ""),
         )


### PR DESCRIPTION
## 연관 이슈
- Refs #54
- Refs #49

## 변경 내용
- retrieval 점수화 로직을 개선해 `task_family` 중심 매칭과 slot(`from`, `to`) 일치 반영을 강화
- 후보 품질 band(high/mid/low)와 최소 점수 기준을 도입해 저품질 후보를 필터링
- 중복 후보를 dedupe하고 우선순위(점수/slot specificity/충돌수/성공률/최신성) 기반으로 top-k를 선별
- memory context를 실행 지향 `DO/DON'T` 규칙 형태로 재구성해 주입 품질을 개선
- `submit` 경로에서 single 모드 기준으로 long-term 메모리 주입을 적용하고 top-k 기본값을 3으로 조정

## 테스트
- [x] 로컬 실행 테스트 완료
- [x] 회귀 영향 확인