### PR TITLE
feat: static map 기반 초기 turtle1/2/3 스폰 지원

### DIFF
--- a/src/turtle_agent/config/static_obstacles_turtlesim.yaml
+++ b/src/turtle_agent/config/static_obstacles_turtlesim.yaml
@@ -80,3 +80,19 @@ obstacles:
       cx: 2.0
       cy: 9.0
       r: 0.25
+
+# Optional: spawn turtles once static world is loaded.
+# Existing turtles with the same names are removed before spawn.
+initial_turtles:
+  - name: turtle1
+    x: 2.0
+    y: 9.0
+    theta: 0.0
+  - name: turtle2
+    x: 9.0
+    y: 9.0
+    theta: 0.0
+  - name: turtle3
+    x: 9.0
+    y: 2.0
+    theta: 0.0

--- a/src/turtle_agent/scripts/static_world.py
+++ b/src/turtle_agent/scripts/static_world.py
@@ -16,9 +16,81 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
 from obstacle_store import ObstacleStore
 from static_map_loader import StaticMapLoadError, load_file
 from world_builder import draw_static_world
+
+
+def _read_initial_turtles(path: str) -> List[Dict[str, Any]]:
+    """Read optional ``initial_turtles`` list from YAML/JSON config."""
+    p = Path(path)
+    if not p.exists():
+        return []
+    text = p.read_text(encoding="utf-8")
+    suffix = p.suffix.lower()
+    if suffix == ".json":
+        data = json.loads(text)
+    elif suffix in (".yaml", ".yml"):
+        import yaml
+
+        data = yaml.safe_load(text)
+    else:
+        return []
+    if not isinstance(data, dict):
+        return []
+    items = data.get("initial_turtles", [])
+    if not isinstance(items, list):
+        return []
+    out: List[Dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name", "")).replace("/", "").strip()
+        if not name:
+            continue
+        try:
+            x = float(item.get("x"))
+            y = float(item.get("y"))
+            theta = float(item.get("theta", 0.0))
+        except (TypeError, ValueError):
+            continue
+        out.append({"name": name, "x": x, "y": y, "theta": theta})
+    return out
+
+
+def _spawn_initial_turtles(specs: List[Dict[str, Any]]) -> None:
+    """Spawn turtles from config to fixed initial points.
+
+    Existing turtles with the same names are removed first. This allows
+    overriding the default center-spawned ``turtle1`` as well.
+    """
+    if not specs:
+        return
+    import rospy
+    from turtlesim.srv import Kill, Spawn
+
+    rospy.wait_for_service("/spawn", timeout=5.0)
+    rospy.wait_for_service("/kill", timeout=5.0)
+    spawn = rospy.ServiceProxy("/spawn", Spawn)
+    kill = rospy.ServiceProxy("/kill", Kill)
+
+    for spec in specs:
+        name = spec["name"]
+        x = spec["x"]
+        y = spec["y"]
+        theta = spec["theta"]
+        try:
+            try:
+                kill(name)
+            except Exception:
+                pass
+            spawn(x=x, y=y, theta=theta, name=name)
+        except Exception as e:
+            rospy.logwarn("initial turtle spawn skipped for %s: %s", name, e)
 
 
 def load_static_world(obstacle_store: ObstacleStore) -> None:
@@ -40,3 +112,13 @@ def load_static_world(obstacle_store: ObstacleStore) -> None:
                 rospy.logerr("static world builder failed: %s", e)
                 if rospy.get_param("~world_builder_required", True):
                     raise
+        try:
+            initial_turtles = _read_initial_turtles(path)
+            _spawn_initial_turtles(initial_turtles)
+            if initial_turtles:
+                rospy.loginfo(
+                    "spawned initial turtles from map config: %s",
+                    ", ".join(t["name"] for t in initial_turtles),
+                )
+        except Exception as e:
+            rospy.logwarn("initial turtle spawn skipped: %s", e)


### PR DESCRIPTION
﻿## Summary
- static_obstacles_turtlesim.yaml에 initial_turtles 섹션을 추가해 시작 시 	urtle1/2/3을 지정 좌표로 생성하도록 했습니다.
- static_world.py에서 map 로드 후 initial_turtles를 파싱하고, 이름별 kill -> spawn으로 기본 center spawn 터틀을 대체합니다.
- 설정 파싱/스폰 실패는 warning 로그로 남기고 전체 실행은 유지하도록 처리했습니다.

## Related issue
- Closes #56

## Test plan
- [x] map에 initial_turtles 설정 후 실행 시 	urtle1/2/3이 지정 좌표에 생성되는지 확인
- [x] 	urtle1이 center가 아닌 설정 좌표로 대체되는지 확인
- [x] 잘못된 엔트리(빈 name/좌표 누락)에서 warning 처리 확인
