### PR TITLE
fix: run-agent fallback warning quote parsing hotfix

### DIFF
--- a/run-agent-en.sh
+++ b/run-agent-en.sh
@@ -38,7 +38,7 @@ fi
 if command -v rlwrap >/dev/null 2>&1; then
   rlwrap -cAr roslaunch /app/src/turtle_agent/launch/agent.launch streaming:=${STREAMING}
 else
-  echo "[WARN] rlwrap unavailable; arrow-key editing may still be broken."
+  echo '[WARN] rlwrap unavailable; arrow-key editing may still be broken.'
   roslaunch /app/src/turtle_agent/launch/agent.launch streaming:=${STREAMING}
 fi
 "


### PR DESCRIPTION
﻿## Summary
- un-agent-en.sh의 fallback warning 출력에서 큰따옴표를 작은따옴표로 바꿨습니다.
- Docker 내부 ash -lc 문자열이 중간에 끊기던 문제를 막아 lwrap: -c: ... unexpected end of file 오류를 해결합니다.

## Test plan
- [x] ./run-agent-en.sh 실행 시 rlwrap EOF syntax error 재현되지 않음 확인
- [x] rlwrap 미설치 fallback 경로에서도 스크립트 파싱 오류 없이 진행 확인
