### PR TITLE
fix: reset_turtlesim static-world 복구 연동

### DIFF
--- a/src/turtle_agent/config/static_obstacles_turtlesim.yaml
+++ b/src/turtle_agent/config/static_obstacles_turtlesim.yaml
@@ -80,10 +80,6 @@ obstacles:
       cx: 2.0
       cy: 9.0
       r: 0.25
-<<<<<<< fix/initial-turtle-headings
-=======
-
->>>>>>> dev
 # Optional: spawn turtles once static world is loaded.
 # Existing turtles with the same names are removed before spawn.
 initial_turtles:
@@ -94,16 +90,8 @@ initial_turtles:
   - name: turtle2
     x: 9.0
     y: 9.0
-<<<<<<< fix/initial-turtle-headings
     theta: 4.71238898038
   - name: turtle3
     x: 9.0
     y: 2.0
     theta: 3.14159265359
-=======
-    theta: 0.0
-  - name: turtle3
-    x: 9.0
-    y: 2.0
-    theta: 0.0
->>>>>>> dev

--- a/src/turtle_agent/scripts/tools/obstacle.py
+++ b/src/turtle_agent/scripts/tools/obstacle.py
@@ -48,6 +48,11 @@ def configure_obstacle_store(store: ObstacleStore) -> None:
     _STORE = store
 
 
+def get_configured_obstacle_store() -> Optional[ObstacleStore]:
+    """Return currently configured in-process ObstacleStore, if any."""
+    return _STORE
+
+
 def _require_store() -> ObstacleStore:
     if _STORE is None:
         raise ObstacleToolError("ObstacleStore is not configured.")

--- a/src/turtle_agent/scripts/tools/turtle.py
+++ b/src/turtle_agent/scripts/tools/turtle.py
@@ -19,6 +19,8 @@ import rospy
 from geometry_msgs.msg import Twist
 from langchain.agents import tool
 from std_srvs.srv import Empty
+from static_world import load_static_world
+import tools.obstacle as obstacle_tools
 from turtle_lifecycle import (
     configure_turtle_lifecycle_listener,
     notify_turtle_killed,
@@ -372,7 +374,12 @@ def stop_turtle(name: str):
 @tool
 def reset_turtlesim():
     """
-    Resets the turtlesim, removes all turtles, clears any markings, and creates a new default turtle at the center.
+    Reset turtlesim and restore static-world initial state.
+
+    This now does:
+    1) turtlesim /reset (clears drawing + returns default turtle behavior)
+    2) static map reload + redraw
+    3) initial_turtles respawn/reposition from static map config
     """
     try:
         rospy.wait_for_service("/reset", timeout=5)
@@ -391,9 +398,21 @@ def reset_turtlesim():
             f"/turtle1/cmd_vel", Twist, queue_size=10
         )
 
-        return "Successfully reset the turtlesim environment. Ignore all previous commands, failures, and goals."
+        store = obstacle_tools.get_configured_obstacle_store()
+        if store is None:
+            return (
+                "Reset completed, but static world restore was skipped because "
+                "ObstacleStore is not configured."
+            )
+        load_static_world(store)
+        return (
+            "Successfully reset turtlesim and restored static world from map "
+            "(obstacles + initial turtles)."
+        )
     except rospy.ServiceException as e:
         return f"Failed to reset the turtlesim environment: {e}"
+    except Exception as e:
+        return f"Reset succeeded but static world restore failed: {e}"
 
 
 @tool


### PR DESCRIPTION
﻿## Summary
- eset_turtlesim 호출 시 turtlesim 리셋 후 static map을 다시 로드해 장애물과 initial_turtles 배치를 함께 복구하도록 확장했습니다.
- obstacle tool 모듈에 configured ObstacleStore getter를 추가해 reset tool에서 동일 store를 재사용하도록 연결했습니다.
- static_obstacles_turtlesim.yaml에 남아 있던 merge marker를 제거해 YAML 파싱 오류를 함께 정리했습니다.

## Related issue
- Relates #56

## Test plan
- [x] 실행 중 eset_turtlesim 호출 후 장애물/초기 터틀 위치가 YAML 기준으로 복구되는지 확인
- [x] 리셋 직후 list_obstacles, get_turtle_pose(names=['turtle1','turtle2','turtle3'])로 상태 확인
- [x] static map YAML 파싱 오류(merge marker) 재발 없음 확인
