### PR TITLE
feat: 다중 거북이 제어 안정화 및 reset 직호출 추가

### DIFF
--- a/src/turtle_agent/scripts/tools/turtle.py
+++ b/src/turtle_agent/scripts/tools/turtle.py
@@ -42,6 +42,16 @@ def remove_cmd_vel_pub(name: str):
     cmd_vel_pubs.pop(name, None)
 
 
+def get_or_create_cmd_vel_pub(name: str) -> rospy.Publisher:
+    """Return cmd_vel publisher for turtle, creating it on demand."""
+    global cmd_vel_pubs
+    pub = cmd_vel_pubs.get(name)
+    if pub is None:
+        pub = rospy.Publisher(f"/{name}/cmd_vel", Twist, queue_size=10)
+        cmd_vel_pubs[name] = pub
+    return pub
+
+
 # Add the default turtle1 publisher on startup
 add_cmd_vel_pub("turtle1", rospy.Publisher(f"/turtle1/cmd_vel", Twist, queue_size=10))
 
@@ -321,7 +331,7 @@ def publish_twist_to_cmd_vel(
 
     try:
         global cmd_vel_pubs
-        pub = cmd_vel_pubs[name]
+        pub = get_or_create_cmd_vel_pub(name)
 
         # Publish continuously during each second-step to avoid undershooting.
         publish_hz = 20
@@ -357,7 +367,7 @@ def stop_turtle(name: str):
     name = name.replace("/", "")
     try:
         global cmd_vel_pubs
-        pub = cmd_vel_pubs[name]
+        pub = get_or_create_cmd_vel_pub(name)
         stop = Twist()
         for _ in range(3):
             pub.publish(stop)
@@ -394,9 +404,10 @@ def reset_turtlesim():
         # Clear the cmd_vel publishers
         global cmd_vel_pubs
         cmd_vel_pubs.clear()
-        cmd_vel_pubs["turtle1"] = rospy.Publisher(
-            f"/turtle1/cmd_vel", Twist, queue_size=10
-        )
+        for turtle_name in ("turtle1", "turtle2", "turtle3"):
+            cmd_vel_pubs[turtle_name] = rospy.Publisher(
+                f"/{turtle_name}/cmd_vel", Twist, queue_size=10
+            )
 
         store = obstacle_tools.get_configured_obstacle_store()
         if store is None:

--- a/src/turtle_agent/scripts/turtle_agent.py
+++ b/src/turtle_agent/scripts/turtle_agent.py
@@ -199,6 +199,7 @@ class TurtleAgent(ROSA):
             "help": lambda: self.submit(get_help(self.examples)),
             "examples": lambda: self.submit(self.choose_example()),
             "clear": lambda: self.clear(),
+            "reset": lambda: self.run_reset_command(),
         }
 
     def _record_agent_tool_steps(self, intermediate_steps: List[Tuple[Any, Any]]) -> None:
@@ -325,6 +326,45 @@ class TurtleAgent(ROSA):
             except Exception as e:
                 console.print(f"[red]Error: {e}[/red]")
                 continue
+
+    async def run_reset_command(self):
+        """Run reset tool directly without LLM interpretation."""
+        console = Console()
+        try:
+            result = turtle_tools.reset_turtlesim.invoke({})
+            self.last_user_query = "reset"
+            self.last_events = [
+                {
+                    "type": "tool_start",
+                    "name": "reset_turtlesim",
+                    "input": {},
+                    "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3],
+                },
+                {
+                    "type": "tool_end",
+                    "name": "reset_turtlesim",
+                    "output": str(result),
+                    "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3],
+                },
+            ]
+            self.command_handler["info"] = self.show_event_details
+            console.print(
+                Panel(
+                    Markdown(str(result) + "\n\nType `info` for reset execution details."),
+                    title="Reset Command",
+                    border_style="green",
+                )
+            )
+        except Exception as e:
+            self.last_events = [
+                {
+                    "type": "error",
+                    "content": f"reset command failed: {e}",
+                    "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3],
+                }
+            ]
+            self.command_handler["info"] = self.show_event_details
+            console.print(f"[red]reset command failed: {e}[/red]")
 
     async def submit(self, query: str):
         self.last_user_query = query

--- a/src/turtle_agent/scripts/turtle_agent.py
+++ b/src/turtle_agent/scripts/turtle_agent.py
@@ -163,6 +163,7 @@ class TurtleAgent(ROSA):
         )
         self._agent_mode = str(rospy.get_param("~agent_mode", "single"))
         self._memory_root = (Path(__file__).resolve().parent / "memory").resolve()
+        self.last_user_query = ""
 
         # Another method for adding tools
         blast_off = Tool(
@@ -222,6 +223,19 @@ class TurtleAgent(ROSA):
                 args=args,
                 status="success",
                 result=str(observation)[:4000],
+            )
+            # Keep lightweight tool traces so `info` works in non-streaming mode as well.
+            ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+            self.last_events.append(
+                {"type": "tool_start", "name": str(tool_name), "input": args, "timestamp": ts}
+            )
+            self.last_events.append(
+                {
+                    "type": "tool_end",
+                    "name": str(tool_name),
+                    "output": str(observation)[:4000],
+                    "timestamp": ts,
+                }
             )
 
     def blast_off(self, input: str):
@@ -313,6 +327,8 @@ class TurtleAgent(ROSA):
                 continue
 
     async def submit(self, query: str):
+        self.last_user_query = query
+        self.last_events = []
         query_ctx = infer_query_context(query)
         memory_context = ""
         memory_hits = 0
@@ -343,6 +359,10 @@ class TurtleAgent(ROSA):
             response = await self.stream_response(effective_query)
         else:
             response = self.print_response(effective_query)
+        if self.last_events:
+            self.command_handler["info"] = self.show_event_details
+        else:
+            self.command_handler.pop("info", None)
         self._command_logger.log_skill(
             self._turtle_id,
             skill="rosa_response",
@@ -482,6 +502,17 @@ class TurtleAgent(ROSA):
             return
         else:
             console.print(Markdown("# Tool Usage and Events"))
+            if self.last_user_query:
+                console.print(
+                    Panel(
+                        Group(
+                            Text(self.last_user_query),
+                            Text("Most recent user query", style="dim"),
+                        ),
+                        title="User Query",
+                        border_style="magenta",
+                    )
+                )
 
         for event in self.last_events:
             timestamp = event["timestamp"]


### PR DESCRIPTION
﻿## Summary
- `reset_turtlesim`이 static map 기준으로 장애물과 초기 turtle 배치를 함께 복구하도록 연동했습니다.
- multi-turtle 제어 안정화를 위해 `cmd_vel` publisher를 자동 재등록/온디맨드 생성하도록 개선했습니다.
- 에이전트에 `reset` 직호출 커맨드를 추가해 LLM 해석 없이 즉시 reset 실행되도록 했고, `info`에서 최근 사용자 쿼리와 실행 이벤트를 일관되게 확인할 수 있게 했습니다.

## Related issue
- Relates #56

## Test plan
- [x] `reset` 입력 시 즉시 `reset_turtlesim`이 실행되고 결과가 바로 출력되는지 확인
- [x] `info`에서 최근 쿼리(User Query) 및 reset 실행 이벤트가 표시되는지 확인
- [x] reset 이후 `turtle2`, `turtle3`의 이동/정지 명령이 `KeyError` 없이 동작하는지 확인
