### PR TITLE
feat: 경로 충돌 검사 도구 추가

### DIFF
--- a/.cursor/plans/경로_충돌_도구_3e7df8d2.plan.md
+++ b/.cursor/plans/경로_충돌_도구_3e7df8d2.plan.md
@@ -1,0 +1,128 @@
+---
+name: 경로 충돌 도구
+overview: 이슈 64의 도구 추가 변경만 별도 PR로 분리할 수 있도록, 다른 개발자가 참고 가능한 구현 계획을 정리합니다. 범위는 장애물 경로 검증 tool과 관련 테스트로 제한합니다.
+todos:
+  - id: isolate-files
+    content: 이슈 64 PR에는 `obstacle.py`와 `test_obstacle_tools.py`의 관련 변경만 포함한다.
+    status: pending
+  - id: add-path-tool
+    content: "`check_path_against_obstacles`와 충돌 판정 helper를 `obstacle.py`에 추가한다."
+    status: pending
+  - id: add-tests
+    content: temporary AABB 차단, 우회 허용, static 기본 제외 테스트를 추가한다.
+    status: pending
+  - id: verify
+    content: linter, py_compile, 가능한 경우 unittest로 변경을 검증한다.
+    status: pending
+isProject: false
+---
+
+# 경로 충돌 검사 도구 구현 계획
+
+## 목표
+
+- TurtleAgent가 이동 전 경로 안전성을 확인할 수 있도록 장애물 경로 충돌 검사 도구를 추가한다.
+- 기본 검사 대상은 `temporary` 장애물로 제한해, 사용자가 “장애물을 피하라”고 요청했을 때 임시 장애물을 통과하지 않도록 한다.
+- 이 계획은 이미 구현된 변경을 다른 개발자가 검토·재현할 수 있도록 작성한 참조용 계획이다.
+
+## 포함 범위
+
+- [`/Users/jongphago/Documents/Projects/rosa/src/turtle_agent/scripts/tools/obstacle.py`](/Users/jongphago/Documents/Projects/rosa/src/turtle_agent/scripts/tools/obstacle.py)
+  - `collision_geometry.py`의 기존 충돌 판정 함수 재사용
+  - 경로 segment와 장애물 geometry 간 충돌 여부를 판단하는 내부 helper 추가
+  - LangChain tool인 `check_path_against_obstacles` 추가
+
+- [`/Users/jongphago/Documents/Projects/rosa/tests/test_turtle_agent/test_obstacle_tools.py`](/Users/jongphago/Documents/Projects/rosa/tests/test_turtle_agent/test_obstacle_tools.py)
+  - 임시 AABB 장애물 통과 차단 테스트
+  - 임시 AABB 장애물 우회 허용 테스트
+  - 기본값에서는 static 장애물을 검사하지 않고, 명시 시 검사하는 동작 테스트
+
+## 제외 범위
+
+- `prompts.py` 프롬프트 변경
+- `memory_prompting.py` 메모리 정책 변경
+- 로그 파일 변경
+- 실행 환경 설정 변경
+- 기존 이동 도구의 동작 변경
+
+## 구현 단계
+
+1. `obstacle.py`에 충돌 판정 함수 import를 추가한다.
+
+```python
+from collision_geometry import (
+    any_segment_intersects_disc,
+    circle_intersects_aabb,
+    segment_intersects_disc,
+)
+```
+
+2. 경로와 AABB 교차를 판단하는 내부 helper를 추가한다.
+
+- 목적: `wet` 같은 사각형 장애물의 확장 영역을 이동 선분이 통과하는지 판단한다.
+- 함수: `_segment_intersects_aabb`
+
+3. segment 장애물 대응 helper를 추가한다.
+
+- 목적: 벽이나 선분 장애물과 터틀 이동 경로가 직접 교차하거나, 터틀 반경 및 안전 여유 거리 안에 들어오는지 판단한다.
+- 함수: `_point_on_segment`, `_orientation`, `_segments_intersect`, `_segments_within_distance`
+
+4. 단일 장애물 판정 helper를 추가한다.
+
+- 목적: 장애물 geometry 종류에 따라 적절한 충돌 판정 함수를 선택한다.
+- 함수: `_path_hits_obstacle`
+- 처리 기준:
+  - circle: 장애물 반경에 clearance를 더해 선분-원 교차 검사
+  - aabb: AABB를 clearance만큼 확장한 뒤 선분-AABB 교차 검사
+  - segments: 경로와 장애물 선분의 교차 또는 clearance 이내 접근 검사
+
+5. LangChain tool을 추가한다.
+
+- 함수: `check_path_against_obstacles`
+- 입력:
+  - 시작 좌표
+  - 종료 좌표
+  - 터틀 반경
+  - 안전 여유 거리
+  - 검사할 장애물 종류 목록
+- 기본값:
+  - `turtle_radius=0.5`
+  - `safety_margin=0.2`
+  - `obstacle_kinds="temporary"`
+- 반환:
+  - JSON 문자열
+  - `safe`: 이동 가능 여부
+  - `blocked_by`: 충돌 가능성이 있는 장애물 목록
+  - `recommendation`: 진행 또는 재계획 권고
+
+6. 단위 테스트를 추가한다.
+
+- temporary AABB를 관통하는 경로는 `safe=false`가 되어야 한다.
+- temporary AABB를 충분히 우회하는 경로는 `safe=true`가 되어야 한다.
+- static 장애물은 기본 검사 대상에서 제외되어야 하며, 검사 대상에 명시하면 차단되어야 한다.
+
+## 기대 동작
+
+```mermaid
+flowchart TD
+  userCommand["고수준 이동 명령"] --> planSegment["이동 segment 계획"]
+  planSegment --> checkPath["check_path_against_obstacles 호출"]
+  checkPath --> safeDecision{"safe 여부"}
+  safeDecision -->|"true"| moveTool["publish_twist_to_cmd_vel 실행"]
+  safeDecision -->|"false"| replan["우회 경로 재계획"]
+```
+
+## 검증 계획
+
+- 정적 확인:
+  - `ReadLints`로 `obstacle.py`, `test_obstacle_tools.py` 진단 오류 확인
+  - `python3 -m py_compile src/turtle_agent/scripts/tools/obstacle.py tests/test_turtle_agent/test_obstacle_tools.py`
+
+- 단위 테스트:
+  - `uv run python -m unittest tests.test_turtle_agent.test_obstacle_tools`
+
+## 확인된 제약
+
+- 시스템 Python에서는 `langchain` 미설치로 unittest import가 실패할 수 있다.
+- `uv run` 기반 테스트는 환경 상태에 따라 의존성 준비 단계에서 오래 걸릴 수 있다.
+- 이번 변경은 도구 추가에 한정되며, LLM이 이 도구를 반드시 호출하도록 만드는 프롬프트 강화는 별도 이슈/PR에서 다룬다.

--- a/src/turtle_agent/scripts/tools/obstacle.py
+++ b/src/turtle_agent/scripts/tools/obstacle.py
@@ -26,6 +26,11 @@ from typing import Any, Dict, Optional
 
 from langchain.agents import tool
 
+from collision_geometry import (
+    any_segment_intersects_disc,
+    circle_intersects_aabb,
+    segment_intersects_disc,
+)
 from obstacle_store import (
     AabbGeometry,
     CircleGeometry,
@@ -141,6 +146,185 @@ def _geometry_to_dict(geometry: ObstacleGeometry) -> Dict[str, Any]:
     }
 
 
+def _segment_intersects_aabb(
+    x1: float,
+    y1: float,
+    x2: float,
+    y2: float,
+    min_x: float,
+    min_y: float,
+    max_x: float,
+    max_y: float,
+) -> bool:
+    """Return True when a line segment intersects an axis-aligned box."""
+    dx = x2 - x1
+    dy = y2 - y1
+    t_min = 0.0
+    t_max = 1.0
+
+    for p, q in (
+        (-dx, x1 - min_x),
+        (dx, max_x - x1),
+        (-dy, y1 - min_y),
+        (dy, max_y - y1),
+    ):
+        if p == 0.0:
+            if q < 0.0:
+                return False
+            continue
+        ratio = q / p
+        if p < 0.0:
+            t_min = max(t_min, ratio)
+        else:
+            t_max = min(t_max, ratio)
+        if t_min > t_max:
+            return False
+    return True
+
+
+def _point_on_segment(
+    px: float,
+    py: float,
+    x1: float,
+    y1: float,
+    x2: float,
+    y2: float,
+) -> bool:
+    return (
+        min(x1, x2) <= px <= max(x1, x2)
+        and min(y1, y2) <= py <= max(y1, y2)
+        and (py - y1) * (x2 - x1) == (px - x1) * (y2 - y1)
+    )
+
+
+def _orientation(
+    ax: float,
+    ay: float,
+    bx: float,
+    by: float,
+    cx: float,
+    cy: float,
+) -> int:
+    value = (by - ay) * (cx - bx) - (bx - ax) * (cy - by)
+    if value == 0.0:
+        return 0
+    return 1 if value > 0.0 else 2
+
+
+def _segments_intersect(
+    ax1: float,
+    ay1: float,
+    ax2: float,
+    ay2: float,
+    bx1: float,
+    by1: float,
+    bx2: float,
+    by2: float,
+) -> bool:
+    o1 = _orientation(ax1, ay1, ax2, ay2, bx1, by1)
+    o2 = _orientation(ax1, ay1, ax2, ay2, bx2, by2)
+    o3 = _orientation(bx1, by1, bx2, by2, ax1, ay1)
+    o4 = _orientation(bx1, by1, bx2, by2, ax2, ay2)
+    if o1 != o2 and o3 != o4:
+        return True
+    return (
+        (o1 == 0 and _point_on_segment(bx1, by1, ax1, ay1, ax2, ay2))
+        or (o2 == 0 and _point_on_segment(bx2, by2, ax1, ay1, ax2, ay2))
+        or (o3 == 0 and _point_on_segment(ax1, ay1, bx1, by1, bx2, by2))
+        or (o4 == 0 and _point_on_segment(ax2, ay2, bx1, by1, bx2, by2))
+    )
+
+
+def _segments_within_distance(
+    ax1: float,
+    ay1: float,
+    ax2: float,
+    ay2: float,
+    bx1: float,
+    by1: float,
+    bx2: float,
+    by2: float,
+    distance: float,
+) -> bool:
+    """Return True when two segments are within ``distance`` of each other."""
+    return (
+        _segments_intersect(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2)
+        or segment_intersects_disc(ax1, ay1, ax2, ay2, bx1, by1, distance)
+        or segment_intersects_disc(ax1, ay1, ax2, ay2, bx2, by2, distance)
+        or segment_intersects_disc(bx1, by1, bx2, by2, ax1, ay1, distance)
+        or segment_intersects_disc(bx1, by1, bx2, by2, ax2, ay2, distance)
+    )
+
+
+def _path_hits_obstacle(
+    x1: float,
+    y1: float,
+    x2: float,
+    y2: float,
+    obstacle: Obstacle,
+    clearance: float,
+) -> Optional[str]:
+    geometry = obstacle.geometry
+    if isinstance(geometry, CircleGeometry):
+        if segment_intersects_disc(
+            x1, y1, x2, y2, geometry.cx, geometry.cy, geometry.r + clearance
+        ):
+            return "segment intersects circle inflated by turtle radius and safety margin"
+        return None
+    if isinstance(geometry, AabbGeometry):
+        inflated = {
+            "min_x": geometry.min_x - clearance,
+            "min_y": geometry.min_y - clearance,
+            "max_x": geometry.max_x + clearance,
+            "max_y": geometry.max_y + clearance,
+        }
+        if (
+            circle_intersects_aabb(
+                x1,
+                y1,
+                clearance,
+                geometry.min_x,
+                geometry.min_y,
+                geometry.max_x,
+                geometry.max_y,
+            )
+            or circle_intersects_aabb(
+                x2,
+                y2,
+                clearance,
+                geometry.min_x,
+                geometry.min_y,
+                geometry.max_x,
+                geometry.max_y,
+            )
+            or _segment_intersects_aabb(x1, y1, x2, y2, **inflated)
+        ):
+            return "segment crosses AABB inflated by turtle radius and safety margin"
+        return None
+    if isinstance(geometry, SegmentsGeometry):
+        if (
+            any_segment_intersects_disc(geometry.segments, x1, y1, clearance)
+            or any_segment_intersects_disc(geometry.segments, x2, y2, clearance)
+            or any(
+                _segments_within_distance(
+                    x1,
+                    y1,
+                    x2,
+                    y2,
+                    sx1,
+                    sy1,
+                    sx2,
+                    sy2,
+                    clearance,
+                )
+                for (sx1, sy1), (sx2, sy2) in geometry.segments
+            )
+        ):
+            return "segment passes within turtle radius and safety margin of obstacle segment"
+        return None
+    raise TypeError(f"unsupported obstacle geometry: {type(geometry).__name__}")
+
+
 @tool
 def add_obstacle(
     obstacle_id: str,
@@ -231,3 +415,85 @@ def list_obstacles(include_expired: bool = False) -> str:
         return json.dumps({"obstacles": rows}, ensure_ascii=False, sort_keys=True)
     except ObstacleToolError as e:
         return f"Failed to list obstacles: {e}"
+
+
+@tool
+def check_path_against_obstacles(
+    x1: float,
+    y1: float,
+    x2: float,
+    y2: float,
+    turtle_radius: float = 0.5,
+    safety_margin: float = 0.2,
+    obstacle_kinds: str = "temporary",
+) -> str:
+    """
+    Check whether a straight turtle movement segment would collide with obstacles.
+
+    Use this before moving through ``publish_twist_to_cmd_vel`` when the user asks
+    to avoid obstacles. ``obstacle_kinds`` is a comma-separated filter such as
+    ``temporary`` or ``temporary,static``.
+    """
+    try:
+        start_x = _coerce_float(x1, "x1")
+        start_y = _coerce_float(y1, "y1")
+        end_x = _coerce_float(x2, "x2")
+        end_y = _coerce_float(y2, "y2")
+        radius = _coerce_float(turtle_radius, "turtle_radius")
+        margin = _coerce_float(safety_margin, "safety_margin")
+        if radius < 0:
+            raise ObstacleToolError("turtle_radius must be non-negative.")
+        if margin < 0:
+            raise ObstacleToolError("safety_margin must be non-negative.")
+        kinds = {
+            item.strip().lower()
+            for item in str(obstacle_kinds).split(",")
+            if item.strip()
+        }
+        if not kinds:
+            raise ObstacleToolError("obstacle_kinds must include at least one kind.")
+
+        clearance = radius + margin
+        blocked_by = []
+        for obstacle in _require_store().snapshot():
+            if obstacle.kind not in kinds:
+                continue
+            reason = _path_hits_obstacle(
+                start_x,
+                start_y,
+                end_x,
+                end_y,
+                obstacle,
+                clearance,
+            )
+            if reason:
+                blocked_by.append(
+                    {
+                        "id": obstacle.id,
+                        "kind": obstacle.kind,
+                        "geometry": _geometry_to_dict(obstacle.geometry),
+                        "reason": reason,
+                    }
+                )
+
+        return json.dumps(
+            {
+                "safe": not blocked_by,
+                "start": [start_x, start_y],
+                "end": [end_x, end_y],
+                "turtle_radius": radius,
+                "safety_margin": margin,
+                "clearance": clearance,
+                "checked_kinds": sorted(kinds),
+                "blocked_by": blocked_by,
+                "recommendation": (
+                    "Proceed with this segment."
+                    if not blocked_by
+                    else "Do not execute this segment; replan around blocked_by obstacles."
+                ),
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    except (ObstacleToolError, ValueError, TypeError) as e:
+        return f"Failed to check path against obstacles: {e}"

--- a/tests/test_turtle_agent/test_obstacle_tools.py
+++ b/tests/test_turtle_agent/test_obstacle_tools.py
@@ -97,6 +97,93 @@ class TestObstacleTools(unittest.TestCase):
         listed = json.loads(obstacle_tools.list_obstacles.invoke({}))
         self.assertEqual(listed["obstacles"], [])
 
+    def test_check_path_blocks_temporary_aabb_crossing(self):
+        obstacle_tools.add_obstacle.invoke(
+            {
+                "obstacle_id": "wet",
+                "geometry_json": json.dumps(
+                    {"type": "aabb", "min_x": 5, "min_y": 4, "max_x": 7, "max_y": 6}
+                ),
+                "kind": "temporary",
+                "ttl_seconds": 60,
+            }
+        )
+
+        result = json.loads(
+            obstacle_tools.check_path_against_obstacles.invoke(
+                {
+                    "x1": 1,
+                    "y1": 5,
+                    "x2": 10,
+                    "y2": 5,
+                    "turtle_radius": 0.5,
+                    "safety_margin": 0.2,
+                }
+            )
+        )
+
+        self.assertFalse(result["safe"])
+        self.assertEqual(result["blocked_by"][0]["id"], "wet")
+        self.assertEqual(result["blocked_by"][0]["kind"], "temporary")
+
+    def test_check_path_allows_detour_around_temporary_aabb(self):
+        obstacle_tools.add_obstacle.invoke(
+            {
+                "obstacle_id": "wet",
+                "geometry_json": json.dumps(
+                    {"type": "aabb", "min_x": 5, "min_y": 4, "max_x": 7, "max_y": 6}
+                ),
+                "kind": "temporary",
+                "ttl_seconds": 60,
+            }
+        )
+
+        result = json.loads(
+            obstacle_tools.check_path_against_obstacles.invoke(
+                {
+                    "x1": 1,
+                    "y1": 3.0,
+                    "x2": 10,
+                    "y2": 3.0,
+                    "turtle_radius": 0.5,
+                    "safety_margin": 0.2,
+                }
+            )
+        )
+
+        self.assertTrue(result["safe"])
+        self.assertEqual(result["blocked_by"], [])
+
+    def test_check_path_ignores_static_by_default(self):
+        obstacle_tools.add_obstacle.invoke(
+            {
+                "obstacle_id": "marker",
+                "geometry_json": json.dumps({"type": "circle", "cx": 5, "cy": 5, "r": 1}),
+                "kind": "static",
+            }
+        )
+
+        default_result = json.loads(
+            obstacle_tools.check_path_against_obstacles.invoke(
+                {"x1": 1, "y1": 5, "x2": 10, "y2": 5}
+            )
+        )
+        with_static = json.loads(
+            obstacle_tools.check_path_against_obstacles.invoke(
+                {
+                    "x1": 1,
+                    "y1": 5,
+                    "x2": 10,
+                    "y2": 5,
+                    "obstacle_kinds": "temporary,static",
+                }
+            )
+        )
+
+        self.assertTrue(default_result["safe"])
+        self.assertFalse(with_static["safe"])
+        self.assertEqual(with_static["blocked_by"][0]["id"], "marker")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 연관 이슈
- Closes #64

## 변경 내용
- 터틀 이동 경로가 장애물과 충돌하는지 사전에 검사하는 도구를 추가했습니다.
- 기존 충돌 판정 로직을 재사용해 원형, 사각형, 선분 형태의 장애물을 검사하도록 구성했습니다.
- 기본 검사 대상을 임시 장애물로 두어 “장애물을 피하라”는 고수준 명령에서 임시 장애물 통과를 줄일 수 있도록 했습니다.
- 다른 개발자가 변경 의도와 구현 절차를 확인할 수 있도록 구현 계획 문서를 함께 추가했습니다.

## 테스트
- [x] ReadLints 오류 없음
- [x] `python3 -m py_compile src/turtle_agent/scripts/tools/obstacle.py tests/test_turtle_agent/test_obstacle_tools.py`
- [ ] `uv run python -m unittest tests.test_turtle_agent.test_obstacle_tools`
  - 환경 상태에 따라 장시간 응답이 없어 완료 확인하지 못했습니다.

## 영향 범위
- 경로 충돌 검사 도구 추가만 포함합니다.
- 기존 이동 도구의 실행 방식은 변경하지 않았습니다.
- 프롬프트 및 메모리 정책 변경은 포함하지 않았습니다.

Made with [Cursor](https://cursor.com)