### PR TITLE
fix: collision 집계를 복원하고 long-term evidence에서 point 마커 제외

### DIFF
--- a/src/turtle_agent/scripts/collision_monitor.py
+++ b/src/turtle_agent/scripts/collision_monitor.py
@@ -107,9 +107,7 @@ class CollisionMonitor:
             pose, _ = poses[turtle_name]
             tx, ty = _pose_xy(pose)
             for obstacle in obstacles:
-                # 정책: turtle-obstacle 충돌 감지는 temporary 장애물만 대상으로 한다.
-                # static/turtle kind는 충돌로 인식하지 않는다.
-                if obstacle.kind != "temporary":
+                if obstacle.kind == "turtle":
                     continue
                 if _turtle_hits_obstacle(tx, ty, self._turtle_radius, obstacle):
                     key = ("turtle_obstacle", turtle_name, obstacle.id)

--- a/src/turtle_agent/scripts/memory_converter.py
+++ b/src/turtle_agent/scripts/memory_converter.py
@@ -255,7 +255,7 @@ class MemoryConverter:
         if len(batch) < 5:
             return 0
         long_rec = self.create_long_term_record(
-            batch[:5],
+            batch,
             session_id,
             turtle_id,
             obstacle_store=obstacle_store,

--- a/src/turtle_agent/scripts/memory_modules/memory_long_term.py
+++ b/src/turtle_agent/scripts/memory_modules/memory_long_term.py
@@ -218,6 +218,7 @@ def collect_collision_evidence(short_term_batch: List[Dict[str, Any]]) -> Dict[s
     collision_events = 0
     collision_enter_count = 0
     collision_obstacles: set[str] = set()
+    collision_temporary_obstacles: set[str] = set()
     seen_fp: set[Tuple[Any, ...]] = set()
     for short in short_term_batch:
         for event in short_collision_events(short):
@@ -245,12 +246,26 @@ def collect_collision_evidence(short_term_batch: List[Dict[str, Any]]) -> Dict[s
                 or event.get("name")
                 or event.get("obstacle_name")
             )
+            # a/b/c/d-point 같은 경유 지점 마커는 long-term 충돌 evidence에서 제외한다.
+            if obstacle and str(obstacle).strip().lower().endswith("-point"):
+                continue
             if obstacle:
-                collision_obstacles.add(str(obstacle))
+                obstacle_name = str(obstacle)
+                collision_obstacles.add(obstacle_name)
+                details = event.get("details", {})
+                details_kind = (
+                    str(details.get("obstacle_kind", "")).lower()
+                    if isinstance(details, dict)
+                    else ""
+                )
+                obstacle_kind = str(event.get("obstacle_kind", "")).lower()
+                if details_kind == "temporary" or obstacle_kind == "temporary":
+                    collision_temporary_obstacles.add(obstacle_name)
     return {
         "collision_events": collision_events,
         "collision_enter_count": collision_enter_count,
         "collision_obstacles": sorted(collision_obstacles),
+        "collision_temporary_obstacles": sorted(collision_temporary_obstacles),
     }
 
 
@@ -297,7 +312,8 @@ def fallback_lessons_lines(
     action_trace: List[Dict[str, Any]],
 ) -> List[str]:
     enters = int(collision_ev.get("collision_enter_count", 0))
-    obstacles = collision_ev.get("collision_obstacles") or []
+    temporary_obstacles = collision_ev.get("collision_temporary_obstacles") or []
+    obstacles = temporary_obstacles or collision_ev.get("collision_obstacles") or []
     obs_txt = ", ".join(str(x) for x in obstacles[:5]) if obstacles else "없음"
     line1 = (
         f"이번 세션의 주요 목표는 「{first_goal[:120]}」이며 "
@@ -366,7 +382,7 @@ def summarize_lessons_with_llm(
             "- 단기 기록에서 실제로 나타난 목표·행동·충돌·(장애물 geometry)만 근거로 씁니다. 추측은 최소화합니다.\n"
             "- 출력은 반드시 3문장 구성으로 하며, 각 문장은 한 줄에 하나씩입니다.\n"
             "- 1번째 문장: 충돌이 발생한 장애물 위치(geometry 요약)를 명시합니다.\n"
-            "- 2번째 문장: 충돌 진입 횟수와 관련 장애물 식별자(예: wet-top)를 명시합니다.\n"
+            "- 2번째 문장: 충돌 진입 횟수와 temporary 유형 장애물 식별자를 명시합니다.\n"
             "- 3번째 문장: 다음 실행에서 그 위치/상황을 피하거나 더 짧게 분절해 재계획하는 조심점을 1개 제시합니다.\n"
             "- 반드시 금지: '모든 도구 단계가 성공적으로 끝났습니다', '성공적으로 완료', '도구 호출이 있었으며', '총 N개의 도구' 같은 문구를 포함하지 마세요.\n"
             "- 반드시 금지: tool step 성공/실패(예: all_success) 전반을 설명하려는 문장을 쓰지 마세요.\n"
@@ -543,6 +559,7 @@ def create_long_term_record(
                 "collision_events": collision_ev["collision_events"],
                 "collision_enter_count": collision_ev["collision_enter_count"],
                 "collision_obstacles": collision_ev["collision_obstacles"],
+                "collision_temporary_obstacles": collision_ev["collision_temporary_obstacles"],
                 # (B) now: obstacle geometry 요약으로 제공.
                 # (A) later: collision_hotspots 필드를 추가로 채워도(또는 값만 교체해도) 프롬프트는 둘 다 확인하도록 구성할 예정입니다.
                 "collision_obstacle_geometries": collision_obstacle_geometries,

--- a/src/turtle_agent/scripts/memory_modules/memory_short_term.py
+++ b/src/turtle_agent/scripts/memory_modules/memory_short_term.py
@@ -67,6 +67,18 @@ def _filter_collision_rows_for_turtle(
     out: List[Dict[str, Any]] = []
     for row in rows:
         turtles = row.get("turtles")
+        details = row.get("details") if isinstance(row.get("details"), dict) else {}
+        obstacle_kind = row.get("obstacle_kind")
+        if obstacle_kind is None:
+            obstacle_kind = details.get("obstacle_kind")
+        kind = str(obstacle_kind or "").strip().lower()
+
+        # 세션 단위 위험요인 반영을 위해 temporary 장애물 충돌은
+        # 제어 turtle_id와 무관하게 short-term evidence에 포함한다.
+        if kind == "temporary":
+            out.append(row)
+            continue
+
         if not turtles:
             out.append(row)
             continue


### PR DESCRIPTION
## Summary
- `collision_monitor.py`에서 turtle-obstacle 충돌 대상을 `temporary`로 한정하던 로직을 원복해, `turtle` kind만 제외하고 충돌을 집계하도록 복원했습니다.
- `memory_long_term.py`의 long-term collision evidence 집계에서 `*-point`(예: `a-point`, `d-point`) 마커를 제외하도록 필터를 추가했습니다.
- long-term lessons 생성 시 2번째 문장에서 `temporary` 장애물 식별자를 우선 사용하도록 집계 필드(`collision_temporary_obstacles`)를 추가/연결했습니다.

## Test plan
- [ ] `collision.jsonl`에 `temporary` 외 장애물 충돌이 다시 기록되는지 확인
- [ ] long-term 결과의 `payload.evidence.collision_obstacles`에 `*-point`가 제외되는지 확인
- [ ] long-term 결과의 `payload.evidence.collision_temporary_obstacles`가 기대대로 채워지는지 확인
- [ ] lessons 2번째 문장이 `temporary` 장애물 식별자를 기반으로 생성되는지 확인