### PR TITLE
한국어 질의 전처리 모듈 도입 및 자연어-도구 매핑 안정화

### DIFF
--- a/src/turtle_agent/scripts/ko_query_router.py
+++ b/src/turtle_agent/scripts/ko_query_router.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Optional, Tuple
+
+
+POINT_ALIAS = {
+    "A": "A",
+    "B": "B",
+    "C": "C",
+    "D": "D",
+    "에이": "A",
+    "비": "B",
+    "씨": "C",
+    "디": "D",
+    "에이점": "A",
+    "비점": "B",
+    "씨점": "C",
+    "디점": "D",
+    "A점": "A",
+    "B점": "B",
+    "C점": "C",
+    "D점": "D",
+}
+
+
+def _has_korean(text: str) -> bool:
+    return bool(re.search(r"[가-힣ㄱ-ㅎㅏ-ㅣ]", text))
+
+
+def _normalize_point(raw: str) -> Optional[str]:
+    token = str(raw).strip()
+    if not token:
+        return None
+    token_upper = token.upper()
+    if token_upper in ("A", "B", "C", "D"):
+        return token_upper
+    return POINT_ALIAS.get(token)
+
+
+def _extract_route_slots(query: str) -> Dict[str, Any]:
+    slots: Dict[str, Any] = {}
+    m_ko = re.search(r"([A-Za-z가-힣]+)\s*에서\s*([A-Za-z가-힣]+)\s*로", query)
+    if m_ko:
+        src = _normalize_point(m_ko.group(1))
+        dst = _normalize_point(m_ko.group(2))
+        if src and dst:
+            slots["from"] = src
+            slots["to"] = dst
+    m_xy = re.search(
+        r"\(\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\)\s*에서\s*\(\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\)\s*로",
+        query,
+    )
+    if m_xy:
+        slots["from_xy"] = (float(m_xy.group(1)), float(m_xy.group(2)))
+        slots["to_xy"] = (float(m_xy.group(3)), float(m_xy.group(4)))
+    m_turtle = re.search(r"(turtle\d+)", query, re.IGNORECASE)
+    if m_turtle:
+        slots["turtle"] = m_turtle.group(1).lower()
+    return slots
+
+
+def preprocess_korean_query(query: str) -> Dict[str, Any]:
+    text = str(query or "").strip()
+    lowered = text.lower()
+    uses_korean = _has_korean(text)
+    route_slots = _extract_route_slots(text)
+
+    intent = "generic"
+    confidence = 0.0
+    allowed_tools = []
+
+    if lowered in ("reset", "리셋", "초기화"):
+        intent = "reset"
+        confidence = 1.0
+    elif any(k in lowered for k in ("이동", "가줘", "가 ", "경로", "회피", "에서")):
+        intent = "navigate"
+        confidence = 0.85 if route_slots else 0.65
+        allowed_tools = [
+            "list_obstacles",
+            "check_path_against_obstacles",
+            "draw_line_segment",
+        ]
+
+    hint_lines = []
+    if uses_korean and intent == "navigate":
+        hint_lines.append(
+            "Korean preprocessing hint: This is a navigation request. Resolve route first, then call tools."
+        )
+        hint_lines.append(
+            "Tool policy hint: If path can intersect obstacles, call list_obstacles/check_path_against_obstacles before draw_line_segment."
+        )
+        hint_lines.append(
+            "Safety hint: Prefer segmented line drawing over long one-shot direct movement."
+        )
+        if route_slots.get("from") and route_slots.get("to"):
+            hint_lines.append(
+                f"Route slots: from={route_slots['from']} to={route_slots['to']}"
+            )
+        if route_slots.get("from_xy") and route_slots.get("to_xy"):
+            hint_lines.append(
+                f"Route slots: from_xy={route_slots['from_xy']} to_xy={route_slots['to_xy']}"
+            )
+        if route_slots.get("turtle"):
+            hint_lines.append(f"Turtle slot: {route_slots['turtle']}")
+
+    preprocessing_block = ""
+    if hint_lines:
+        preprocessing_block = "Preprocessing hints:\n" + "\n".join(
+            f"- {line}" for line in hint_lines
+        )
+
+    return {
+        "intent": intent,
+        "confidence": confidence,
+        "slots": route_slots,
+        "allowed_tools": allowed_tools,
+        "normalized_query": text,
+        "preprocessing_block": preprocessing_block,
+        "uses_korean": uses_korean,
+    }
+

--- a/src/turtle_agent/scripts/ko_query_router.py
+++ b/src/turtle_agent/scripts/ko_query_router.py
@@ -23,6 +23,13 @@ POINT_ALIAS = {
     "D점": "D",
 }
 
+POINT_COORDS: Dict[str, Tuple[float, float]] = {
+    "A": (2.0, 9.0),
+    "B": (9.0, 9.0),
+    "C": (9.0, 2.0),
+    "D": (2.0, 2.0),
+}
+
 
 def _has_korean(text: str) -> bool:
     return bool(re.search(r"[가-힣ㄱ-ㅎㅏ-ㅣ]", text))
@@ -57,6 +64,12 @@ def _extract_route_slots(query: str) -> Dict[str, Any]:
     m_turtle = re.search(r"(turtle\d+)", query, re.IGNORECASE)
     if m_turtle:
         slots["turtle"] = m_turtle.group(1).lower()
+    if slots.get("from") and slots.get("to"):
+        from_label = str(slots["from"]).upper()
+        to_label = str(slots["to"]).upper()
+        if from_label in POINT_COORDS and to_label in POINT_COORDS:
+            slots["from_xy"] = POINT_COORDS[from_label]
+            slots["to_xy"] = POINT_COORDS[to_label]
     return slots
 
 
@@ -101,6 +114,10 @@ def preprocess_korean_query(query: str) -> Dict[str, Any]:
             hint_lines.append(
                 f"Route slots: from_xy={route_slots['from_xy']} to_xy={route_slots['to_xy']}"
             )
+            if route_slots.get("from") and route_slots.get("to"):
+                hint_lines.append(
+                    "Point label mapping: A=(2.0,9.0), B=(9.0,9.0), C=(9.0,2.0), D=(2.0,2.0)"
+                )
         if route_slots.get("turtle"):
             hint_lines.append(f"Turtle slot: {route_slots['turtle']}")
 

--- a/src/turtle_agent/scripts/turtle_agent.py
+++ b/src/turtle_agent/scripts/turtle_agent.py
@@ -34,6 +34,7 @@ from collision_event_sink import make_collision_event_sink
 from collision_monitor import CollisionMonitor
 from command_logger import CommandLogger
 from help import get_help
+from ko_query_router import preprocess_korean_query
 from langchain.agents import Tool, tool
 
 # from langchain_ollama import ChatOllama
@@ -369,15 +370,24 @@ class TurtleAgent(ROSA):
     async def submit(self, query: str):
         self.last_user_query = query
         self.last_events = []
-        query_ctx = infer_query_context(query)
+        preprocess = preprocess_korean_query(query)
+        normalized_query = str(preprocess.get("normalized_query", query))
+        query_ctx = infer_query_context(normalized_query)
         memory_context = ""
         memory_hits = 0
         if self._agent_mode.strip().lower() == "single":
             long_records = load_long_term_records(self._memory_root, self._turtle_id)
-            memory_context, memory_hits = build_memory_context(query, long_records, top_k=3)
-        effective_query = (
-            f"{memory_context}\n\nUser query:\n{query}" if memory_context else query
-        )
+            memory_context, memory_hits = build_memory_context(
+                normalized_query, long_records, top_k=3
+            )
+        preprocess_block = str(preprocess.get("preprocessing_block", "")).strip()
+        query_parts: List[str] = []
+        if memory_context:
+            query_parts.append(memory_context)
+        if preprocess_block:
+            query_parts.append(preprocess_block)
+        query_parts.append(f"User query:\n{normalized_query}")
+        effective_query = "\n\n".join(query_parts)
         rospy.loginfo(
             "memory prompt: mode=%s hits=%s experience_key=%s",
             self._agent_mode,
@@ -389,8 +399,8 @@ class TurtleAgent(ROSA):
             {
                 "task_family": str(query_ctx.get("task_family", "natural_language_query")),
                 "slots": query_ctx.get("slots", {}),
-                "natural_language": query,
-                "query": query,
+                "natural_language": normalized_query,
+                "query": normalized_query,
                 "memory_hits": memory_hits,
                 "experience_key": query_ctx.get("experience_key", ""),
             },
@@ -408,8 +418,14 @@ class TurtleAgent(ROSA):
             skill="rosa_response",
             args={
                 "query": query,
+                "normalized_query": normalized_query,
                 "memory_hits": memory_hits,
                 "experience_key": query_ctx.get("experience_key", ""),
+                "korean_preprocess": {
+                    "intent": str(preprocess.get("intent", "")),
+                    "confidence": float(preprocess.get("confidence", 0.0)),
+                    "slots": preprocess.get("slots", {}),
+                },
             },
             status="success",
             result=str(response),

--- a/tests/test_turtle_agent/test_ko_query_router.py
+++ b/tests/test_turtle_agent/test_ko_query_router.py
@@ -16,6 +16,8 @@ class TestKoQueryRouter(unittest.TestCase):
         self.assertGreaterEqual(float(result["confidence"]), 0.8)
         self.assertEqual(result["slots"].get("from"), "A")
         self.assertEqual(result["slots"].get("to"), "B")
+        self.assertEqual(result["slots"].get("from_xy"), (2.0, 9.0))
+        self.assertEqual(result["slots"].get("to_xy"), (9.0, 9.0))
         self.assertEqual(result["slots"].get("turtle"), "turtle1")
         self.assertTrue(result["preprocessing_block"])
 

--- a/tests/test_turtle_agent/test_ko_query_router.py
+++ b/tests/test_turtle_agent/test_ko_query_router.py
@@ -1,0 +1,37 @@
+import sys
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "src" / "turtle_agent" / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+from ko_query_router import preprocess_korean_query  # noqa: E402
+
+
+class TestKoQueryRouter(unittest.TestCase):
+    def test_korean_route_slots_abcd(self):
+        result = preprocess_korean_query("turtle1을 A에서 B로 이동해줘")
+        self.assertEqual(result["intent"], "navigate")
+        self.assertGreaterEqual(float(result["confidence"]), 0.8)
+        self.assertEqual(result["slots"].get("from"), "A")
+        self.assertEqual(result["slots"].get("to"), "B")
+        self.assertEqual(result["slots"].get("turtle"), "turtle1")
+        self.assertTrue(result["preprocessing_block"])
+
+    def test_korean_route_slots_coordinates(self):
+        result = preprocess_korean_query("(2,9)에서 (9,9)로 이동")
+        self.assertEqual(result["intent"], "navigate")
+        self.assertEqual(result["slots"].get("from_xy"), (2.0, 9.0))
+        self.assertEqual(result["slots"].get("to_xy"), (9.0, 9.0))
+
+    def test_reset_query(self):
+        result = preprocess_korean_query("reset")
+        self.assertEqual(result["intent"], "reset")
+        self.assertEqual(float(result["confidence"]), 1.0)
+        self.assertFalse(result["preprocessing_block"])
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## 요약
한국어 자연어 입력을 도구 호출 전에 정규화하는 전처리 모듈을 추가해 의도/슬롯 추출의 일관성을 높였습니다. 전처리 힌트를 LLM 입력에 병합하여 자연어-도구 매핑 안정성을 강화했습니다.

## 변경 내용
- ko_query_router.py 신규 추가
  - 의도 분류(
avigate, eset, generic)
  - 슬롯 추출(A/B/C/D, 좌표, turtle 식별자)
  - 전처리 힌트 블록 생성
- 	urtle_agent.py
  - submit() 앞단에 전처리 연결
  - 정규화 질의 기반 메모리 컨텍스트/의도 추론 적용
  - 전처리 메타(intent/confidence/slots) 로그 기록
- 테스트
  - 	est_ko_query_router.py 신규 추가

## 테스트
- python -m pytest tests/test_turtle_agent/test_ko_query_router.py -q

해결: #75

Made with [Cursor](https://cursor.com)